### PR TITLE
Fix deprecated Dockerfile usages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ COPY ./.docker/nginx.conf /etc/nginx/nginx.conf
 
 COPY --from=build-app /app/dist/browser /usr/share/nginx/html
 
-ENV PORT 8080
-EXPOSE 8080
-CMD sh -c "rm -f /var/log/nginx/* && envsubst '\$PORT' < /etc/nginx/conf.d/configfile.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+ENV PORT=8080
+EXPOSE $PORT
+CMD ["sh", "-c", "rm -f /var/log/nginx/* && envsubst '\\$PORT' < /etc/nginx/conf.d/configfile.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"]


### PR DESCRIPTION
Fixes

* [JSONArgsRecommended](https://docs.docker.com/reference/build-checks/json-args-recommended/)
* [LegacyKeyValueFormat](https://docs.docker.com/reference/build-checks/legacy-key-value-format/)

They are listed in PRs due to Github's scanning.