### PR TITLE
Feature/gb3 1390 info with image preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prepare": "node ./prepare.mjs",
     "update-version": "node ./update-version.js",
     "format-all": "prettier --write ./src",
-    "generate-gb3-api": "npx swagger-typescript-api -p https://maps.zh.ch/api-docs/gb3/v2/swagger.yaml -o ./src/app/shared/models -n gb3-api-generated.interfaces.ts --no-client --extract-response-body --extract-request-body --extract-request-body && node ./remove-generated-api-version-references.js ./src/app/shared/models/gb3-api-generated.interfaces.ts"
+    "generate-gb3-api": "npx swagger-typescript-api -p https://maps.zh.ch/api-docs/gb3/v3/swagger.yaml -o ./src/app/shared/models -n gb3-api-generated.interfaces.ts --no-client --extract-response-body --extract-request-body --extract-request-body && node ./remove-generated-api-version-references.js ./src/app/shared/models/gb3-api-generated.interfaces.ts"
   },
   "private": true,
   "engines": {

--- a/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.html
+++ b/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.html
@@ -1,5 +1,5 @@
 <div class="feature-info-content">
-  <table class="feature-info-content__table" attr.aria-describedby="Informationen zu {{ layer.title }}">
+  <table class="feature-info-content__table" [attr.aria-describedby]="'Informationen zu ' + layer.title">
     <tr class="feature-info-content__table__row">
       <th class="feature-info-content__table__row__column feature-info-content__table__row__column--header" scope="col"></th>
       <th
@@ -56,8 +56,8 @@
                   class="feature-info-content__table__row__column__image"
                   ngSrc="{{ cellValue.src }}"
                   [alt]="cellValue.alt"
-                  width="100"
-                  height="100"
+                  width="200"
+                  height="200"
                 />
               </a>
             }

--- a/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.html
+++ b/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.html
@@ -52,7 +52,13 @@
             }
             @case ('image') {
               <a [href]="cellValue.url" target="_blank" rel="noopener noreferrer" [title]="cellValue.displayValue">
-                <img class="feature-info-content__table__row__column__image" [src]="cellValue.src" [alt]="cellValue.alt" />
+                <img
+                  class="feature-info-content__table__row__column__image"
+                  ngSrc="{{ cellValue.src }}"
+                  [alt]="cellValue.alt"
+                  width="100"
+                  height="100"
+                />
               </a>
             }
             @case ('text') {

--- a/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.html
+++ b/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.html
@@ -37,18 +37,28 @@
           class="feature-info-content__table__row__column"
           tableColumnIdentifier
         >
-          <a
-            class="feature-info-content__table__row__column__link"
-            *ngIf="cellValue.cellType === 'url'; else textCell"
-            [href]="cellValue.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            [title]="cellValue.displayValue"
-          >
-            {{ cellValue.displayValue
-            }}<span class="feature-info-content__table__row__column__link__icon"><mat-icon [inline]="true">north_east</mat-icon></span>
-          </a>
-          <ng-template #textCell>{{ cellValue.displayValue }}</ng-template>
+          @switch (cellValue.cellType) {
+            @case ('url') {
+              <a
+                class="feature-info-content__table__row__column__link"
+                [href]="cellValue.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                [title]="cellValue.displayValue"
+              >
+                {{ cellValue.displayValue
+                }}<span class="feature-info-content__table__row__column__link__icon"><mat-icon [inline]="true">north_east</mat-icon></span>
+              </a>
+            }
+            @case ('image') {
+              <a [href]="cellValue.url" target="_blank" rel="noopener noreferrer" [title]="cellValue.displayValue">
+                <img class="feature-info-content__table__row__column__image" [src]="cellValue.src" [alt]="cellValue.alt" />
+              </a>
+            }
+            @case ('text') {
+              {{ cellValue.displayValue }}
+            }
+          }
         </td>
       </tr>
     </ng-container>

--- a/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.html
+++ b/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.html
@@ -46,8 +46,8 @@
                 rel="noopener noreferrer"
                 [title]="cellValue.displayValue"
               >
-                {{ cellValue.displayValue
-                }}<span class="feature-info-content__table__row__column__link__icon"><mat-icon [inline]="true">north_east</mat-icon></span>
+                {{ cellValue.displayValue }}
+                <span class="feature-info-content__table__row__column__link__icon"><mat-icon [inline]="true">north_east</mat-icon></span>
               </a>
             }
             @case ('image') {

--- a/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.scss
+++ b/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.scss
@@ -122,6 +122,10 @@ $fixed-border: inset calc(-1 * $border-size) 0 0 0 ktzh-variables.$zh-black100;
           }
         }
 
+        .feature-info-content__table__row__column__image {
+          object-fit: contain;
+        }
+
         .feature-info-content__table__row__column__wrapper {
           display: flex;
           justify-content: space-between;

--- a/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.ts
+++ b/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.ts
@@ -11,7 +11,7 @@ import {GeometryWithSrs} from '../../../../shared/interfaces/geojson-types-with-
 import {MAP_SERVICE} from '../../../../app.module';
 import {MapService} from '../../../interfaces/map.service';
 import {LinkObject} from '../../../../shared/interfaces/link-object.interface';
-import {Image} from '../../../../shared/models/gb3-api-generated.interfaces';
+import {Image} from '../../../../shared/interfaces/image.interface';
 
 type CellType = 'text' | 'url' | 'image';
 

--- a/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.ts
+++ b/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.ts
@@ -11,8 +11,9 @@ import {GeometryWithSrs} from '../../../../shared/interfaces/geojson-types-with-
 import {MAP_SERVICE} from '../../../../app.module';
 import {MapService} from '../../../interfaces/map.service';
 import {LinkObject} from '../../../../shared/interfaces/link-object.interface';
+import {Image} from '../../../../shared/models/gb3-api-generated.interfaces';
 
-type CellType = 'text' | 'url';
+type CellType = 'text' | 'url' | 'image';
 
 /**
  * Each TableCell has an fid (identifying the feature), a displayvalue and a type. These are then further narrowed down to handle string
@@ -33,7 +34,14 @@ interface UrlTableCell extends AbstractTableCell {
   url: string;
 }
 
-type TableCell = TextTableCell | UrlTableCell;
+interface ImageTableCell extends AbstractTableCell {
+  cellType: 'image';
+  url: string;
+  src: string;
+  alt: string;
+}
+
+type TableCell = TextTableCell | UrlTableCell | ImageTableCell;
 
 /**
  * A TableHeader is a AbstractTableCell with a displayValue that is string only.
@@ -237,11 +245,22 @@ export class FeatureInfoContentComponent implements OnInit, OnDestroy, AfterView
     return {displayValue, fid, hasGeometry};
   }
 
-  private createTableCellForFeatureAndField(fid: number, value: string | LinkObject | null): TableCell {
+  private createTableCellForFeatureAndField(fid: number, value: string | LinkObject | Image | null): TableCell {
     const displayValue = value ?? DEFAULT_CELL_VALUE;
 
     if (typeof displayValue === 'string') {
       return {cellType: 'text', fid, displayValue};
+    }
+
+    if ('alt' in displayValue) {
+      return {
+        cellType: 'image',
+        fid,
+        displayValue: displayValue.src.title ?? displayValue.src.href,
+        url: displayValue.url.href,
+        src: displayValue.src.href,
+        alt: displayValue.alt,
+      };
     }
 
     return {

--- a/src/app/shared/configs/runtime.config.ts
+++ b/src/app/shared/configs/runtime.config.ts
@@ -9,7 +9,7 @@ export const defaultRuntimeConfig: RuntimeConfig[] = [
     apiBasePaths: {
       gb2Api: {
         baseUrl: 'https://maps.zh.ch/gb3',
-        version: 'v2',
+        version: 'v3',
       },
       gb2StaticFiles: {
         baseUrl: 'https://maps.zh.ch',

--- a/src/app/shared/interfaces/feature-info.interface.ts
+++ b/src/app/shared/interfaces/feature-info.interface.ts
@@ -2,7 +2,7 @@ import {GeometryWithSrs} from './geojson-types-with-srs.interface';
 import {HasMetaDataLink} from './metaDataLink.interface';
 import {IsSingleLayer} from './single-layer.interface';
 import {LinkObject} from './link-object.interface';
-import {Image} from '../models/gb3-api-generated.interfaces';
+import {Image} from './image.interface';
 
 export interface FeatureInfoResultFeatureField {
   label: string;

--- a/src/app/shared/interfaces/feature-info.interface.ts
+++ b/src/app/shared/interfaces/feature-info.interface.ts
@@ -4,10 +4,32 @@ import {IsSingleLayer} from './single-layer.interface';
 import {LinkObject} from './link-object.interface';
 import {Image} from './image.interface';
 
-export interface FeatureInfoResultFeatureField {
+export type FeatureInfoResultFeatureFieldType = 'image' | 'link' | 'text';
+
+export interface AbstractFeatureInfoResultFeatureField {
   label: string;
-  value: string | LinkObject | Image | null;
+  type: FeatureInfoResultFeatureFieldType;
 }
+
+export interface FeatureInfoResultFeatureImageField extends AbstractFeatureInfoResultFeatureField {
+  value: Image;
+  type: 'image';
+}
+
+export interface FeatureInfoResultFeatureLinkField extends AbstractFeatureInfoResultFeatureField {
+  value: LinkObject;
+  type: 'link';
+}
+
+export interface FeatureInfoResultFeatureTextField extends AbstractFeatureInfoResultFeatureField {
+  value: string | null;
+  type: 'text';
+}
+
+export type FeatureInfoResultFeatureField =
+  | FeatureInfoResultFeatureImageField
+  | FeatureInfoResultFeatureLinkField
+  | FeatureInfoResultFeatureTextField;
 
 interface FeatureInfoResultFeature {
   fid: number;

--- a/src/app/shared/interfaces/feature-info.interface.ts
+++ b/src/app/shared/interfaces/feature-info.interface.ts
@@ -2,10 +2,11 @@ import {GeometryWithSrs} from './geojson-types-with-srs.interface';
 import {HasMetaDataLink} from './metaDataLink.interface';
 import {IsSingleLayer} from './single-layer.interface';
 import {LinkObject} from './link-object.interface';
+import {Image} from '../models/gb3-api-generated.interfaces';
 
 export interface FeatureInfoResultFeatureField {
   label: string;
-  value: string | LinkObject | null;
+  value: string | LinkObject | Image | null;
 }
 
 interface FeatureInfoResultFeature {

--- a/src/app/shared/interfaces/image.interface.ts
+++ b/src/app/shared/interfaces/image.interface.ts
@@ -1,0 +1,7 @@
+import {LinkObject} from './link-object.interface';
+
+export interface Image {
+  src: LinkObject;
+  alt: string;
+  url: LinkObject;
+}

--- a/src/app/shared/models/gb3-api-generated.interfaces.ts
+++ b/src/app/shared/models/gb3-api-generated.interfaces.ts
@@ -934,6 +934,16 @@ export interface GeometryCrs {
   };
 }
 
+/** Image source path and meta data */
+export interface Image {
+  /** Source path of the image file for rendering e.g. as thumbnail */
+  src: LinkObject;
+  /** Alternative text of the image for accessiblity purposes */
+  alt: string;
+  /** Link to the original image file */
+  url: LinkObject;
+}
+
 /** Feature field */
 export type InfoFeatureField =
   | {
@@ -941,12 +951,24 @@ export type InfoFeatureField =
       label: string;
       /** Field value (string, numeric or null) */
       value: string | number | null;
+      /** type for the link object */
+      type: string;
     }
   | {
       /** Field label */
       label: string;
       /** Field link */
-      link: LinkObject;
+      value: LinkObject;
+      /** type for the link object */
+      type: string;
+    }
+  | {
+      /** Field label */
+      label: string;
+      /** Field image */
+      value: Image;
+      /** type for the image object */
+      type: string;
     };
 
 /** A link MUST be represented as either: a string containing the link’s URL or a link object. */
@@ -1033,7 +1055,7 @@ export interface Product {
   gdpnummer: number;
   /** Name des Geodatenprodukts */
   name: string;
-  /** Beschreibung */
+  /** Beschreibung des Geoproduktes */
   beschreibung: string;
   datasets: {
     /** Dataset UUID */
@@ -1113,7 +1135,7 @@ export interface Service {
   servicetyp: string;
   /** Name des Geodienstes */
   name: string;
-  /** Beschreibung */
+  /** Beschreibung des Geodienstes */
   beschreibung: string;
   /** URL */
   url: LinkObject;
@@ -1265,8 +1287,6 @@ export type MetadataGeoshopProductsListData = MetadataGeoshopProducts;
 export type MetadataMapsListData = MetadataMaps;
 
 export type MetadataMapsDetailData = MetadataMap;
-
-export type MetadataMapsDetail2Data = MetadataMap;
 
 export type MetadataProductsListData = MetadataProducts;
 

--- a/src/app/shared/models/gb3-api-generated.interfaces.ts
+++ b/src/app/shared/models/gb3-api-generated.interfaces.ts
@@ -678,8 +678,8 @@ export interface Contact {
 export interface Dataset {
   /** UUID */
   uuid: string;
-  /** Link auf Bild */
-  image_url: string | null;
+  /** image object of the thumbnail image */
+  image_url: Image;
   /** Verfügbarkeit OGD/NOGD */
   ogd: boolean;
   /** Kontakt: Verantwortlich für Geodaten */
@@ -951,24 +951,24 @@ export type InfoFeatureField =
       label: string;
       /** Field value (string, numeric or null) */
       value: string | number | null;
-      /** type for the link object */
-      type: string;
+      /** type for the text object (here 'text') */
+      type: 'text';
     }
   | {
       /** Field label */
       label: string;
       /** Field link */
       value: LinkObject;
-      /** type for the link object */
-      type: string;
+      /** type for the link object (here 'link') */
+      type: 'link';
     }
   | {
       /** Field label */
       label: string;
       /** Field image */
       value: Image;
-      /** type for the image object */
-      type: string;
+      /** type for the image object (here 'image') */
+      type: 'image';
     };
 
 /** A link MUST be represented as either: a string containing the link’s URL or a link object. */
@@ -992,10 +992,10 @@ export interface LinkObject {
 export interface Map {
   /** Map UUID */
   uuid: string;
-  /** Link auf Bild */
-  image_url: string | null;
+  /** image object of the thumbnail image */
+  image_url: Image;
   /** Kontakt: Verantwortlich für Geodaten */
-  kontakt_geodaten: Contact;
+  kontakt_metadaten: Contact;
   /** Map GB2-Nummer */
   gb2_id: number;
   /** Topic name */
@@ -1047,8 +1047,8 @@ export interface MunicipalityItem {
 export interface Product {
   /** Product UUID */
   uuid: string;
-  /** Link auf Bild */
-  image_url: string | null;
+  /** image object of the thumbnail image */
+  image_url: Image;
   /** Kontakt: Zuständig für Geometadaten */
   kontakt_metadaten: Contact;
   /** Product GDP-Nummer */
@@ -1125,8 +1125,8 @@ export interface SearchMatch {
 export interface Service {
   /** Service UUID */
   uuid: string;
-  /** Link auf Bild */
-  image_url: string | null;
+  /** image object of the thumbnail image */
+  image_url: Image;
   /** Kontakt: Zuständig für Geometadaten */
   kontakt_metadaten: Contact;
   /** Service GDSer-Nummer */

--- a/src/app/shared/pipes/text-or-placeholder.pipe.ts
+++ b/src/app/shared/pipes/text-or-placeholder.pipe.ts
@@ -5,7 +5,7 @@ import {Pipe, PipeTransform} from '@angular/core';
   standalone: true,
 })
 export class TextOrPlaceholderPipe implements PipeTransform {
-  transform(value: string | null): string {
+  public transform(value: string | null): string {
     return value ?? '-';
   }
 }

--- a/src/app/shared/services/apis/gb3/gb3-metadata.service.spec.ts
+++ b/src/app/shared/services/apis/gb3/gb3-metadata.service.spec.ts
@@ -56,7 +56,7 @@ const mockServiceDetailResponse = {
     ],
     name: 'test-service',
     beschreibung: 'Lorem ipsum dolor',
-    image_url: '/gb3/example/picture.png',
+    image_url: {url: {href: '/gb3/example/picture.png'}, src: {href: '/gb3/example/picture.png'}, alt: 'Testbild'},
     kontakt_metadaten: {...mockContact},
     servicetyp: 'type of service',
     version: '1.0.1b',
@@ -73,8 +73,8 @@ const mockMapDetailResponse = {
       {name: 'data-2', uuid: '2', kurzbeschreibung: 'Lorem ipsum dolor', url_shop: null, giszhnr: 2},
     ],
     beschreibung: 'Lorem ipsum dolor',
-    image_url: '/gb3/example/picture.png',
-    kontakt_geodaten: {...mockContact},
+    image_url: {url: {href: '/gb3/example/picture.png'}, src: {href: '/gb3/example/picture.png'}, alt: 'Testbild'},
+    kontakt_metadaten: {...mockContact},
     name: 'Testmap',
     topic: 'test-topic',
     verweise: [],
@@ -93,7 +93,7 @@ const mockProductDetailResponse = {
       {name: 'data-2', uuid: '2', kurzbeschreibung: 'Lorem ipsum dolor', giszhnr: 1},
     ],
     beschreibung: 'Lorem ipsum dolor',
-    image_url: '/gb3/example/picture.png',
+    image_url: {url: {href: '/gb3/example/picture.png'}, src: {href: '/gb3/example/picture.png'}, alt: 'Testbild'},
     kontakt_metadaten: {...mockContact},
     name: 'Testmap',
   },
@@ -104,7 +104,7 @@ const mockDatasetDetailResponse = {
     uuid: '131',
     gisZHNr: 12,
     beschreibung: 'Lorem ipsum dolor',
-    image_url: '/gb3/example/picture.png',
+    image_url: {url: {href: '/gb3/example/picture.png'}, src: {href: '/gb3/example/picture.png'}, alt: 'Testbild'},
     kontakt_geodaten: {...mockContact},
     kontakt_metadaten: {...mockContact},
     name: 'Testmap',
@@ -212,7 +212,7 @@ describe('Gb3MetadataService', () => {
       const expected: ServiceMetadata = {
         version: mockServiceDetailResponse.service.version,
         url: mockServiceDetailResponse.service.url.href,
-        imageUrl: `${staticFileUrl}${mockServiceDetailResponse.service.image_url}`,
+        imageUrl: `${staticFileUrl}${mockServiceDetailResponse.service.image_url.src.href}`,
         uuid: mockServiceDetailResponse.service.uuid,
         gisZHNr: mockServiceDetailResponse.service.gdsernummer,
         name: mockServiceDetailResponse.service.name,
@@ -256,7 +256,7 @@ describe('Gb3MetadataService', () => {
 
       const expected: MapMetadata = {
         topic: mockMapDetailResponse.map.topic,
-        imageUrl: `${staticFileUrl}${mockMapDetailResponse.map.image_url}`,
+        imageUrl: `${staticFileUrl}${mockMapDetailResponse.map.image_url.src.href}`,
         uuid: mockMapDetailResponse.map.uuid,
         gisZHNr: mockMapDetailResponse.map.gb2_id,
         name: mockMapDetailResponse.map.name,
@@ -299,7 +299,7 @@ describe('Gb3MetadataService', () => {
       spyOn(httpClient, 'get').and.returnValue(of(mockProductDetailResponse));
 
       const expected: ProductMetadata = {
-        imageUrl: `${staticFileUrl}${mockProductDetailResponse.product.image_url}`,
+        imageUrl: `${staticFileUrl}${mockProductDetailResponse.product.image_url.src.href}`,
         uuid: mockProductDetailResponse.product.uuid,
         gisZHNr: mockProductDetailResponse.product.gdpnummer,
         name: mockProductDetailResponse.product.name,
@@ -362,7 +362,7 @@ describe('Gb3MetadataService', () => {
         pdf: mockDatasetDetailResponse.dataset.pdf,
         outputFormat: mockDatasetDetailResponse.dataset.abgabeformate,
         shortDescription: mockDatasetDetailResponse.dataset.kurzbeschreibung,
-        imageUrl: `${staticFileUrl}${mockDatasetDetailResponse.dataset.image_url}`,
+        imageUrl: `${staticFileUrl}${mockDatasetDetailResponse.dataset.image_url.url.href}`,
         uuid: mockDatasetDetailResponse.dataset.uuid,
         gisZHNr: mockDatasetDetailResponse.dataset.giszhnr,
         name: mockDatasetDetailResponse.dataset.name,
@@ -417,7 +417,7 @@ describe('Gb3MetadataService', () => {
               mockMapDetailResponse.map.uuid,
               mockMapDetailResponse.map.name,
               mockMapDetailResponse.map.beschreibung,
-              mockMapDetailResponse.map.kontakt_geodaten.amt,
+              mockMapDetailResponse.map.kontakt_metadaten.amt,
             ),
             new ProductOverviewMetadataItem(
               mockProductDetailResponse.product.uuid,

--- a/src/app/shared/services/apis/gb3/gb3-metadata.service.ts
+++ b/src/app/shared/services/apis/gb3/gb3-metadata.service.ts
@@ -185,7 +185,7 @@ export class Gb3MetadataService extends Gb3ApiService {
       mxd: dataset.mxd ? this.createLinkObject(dataset.mxd) : null,
       lyr: dataset.lyrs,
       pdf: dataset.pdf ? {href: this.createAbsoluteUrl(dataset.pdf.href), title: dataset.pdf.title} : null,
-      imageUrl: dataset.image_url ? this.createAbsoluteUrl(dataset.image_url) : null,
+      imageUrl: dataset.image_url ? this.createAbsoluteUrl(dataset.image_url.src.href) : null,
       contact: {
         geodata: this.extractContactDetails(dataset.kontakt_geodaten),
         metadata: this.extractContactDetails(dataset.kontakt_metadaten),
@@ -220,7 +220,7 @@ export class Gb3MetadataService extends Gb3ApiService {
       gisZHNr: mapData.gb2_id,
       name: mapData.name,
       description: mapData.beschreibung,
-      imageUrl: mapData.image_url ? this.createAbsoluteUrl(mapData.image_url) : null,
+      imageUrl: mapData.image_url ? this.createAbsoluteUrl(mapData.image_url.src.href) : null,
       externalLinks: mapData.verweise,
       gb2Url: mapData.gb2_url
         ? {
@@ -230,7 +230,7 @@ export class Gb3MetadataService extends Gb3ApiService {
         : null,
       datasets: mapData.datasets.map(this.extractDatasetDetail),
       contact: {
-        geodata: this.extractContactDetails(mapData.kontakt_geodaten),
+        geodata: this.extractContactDetails(mapData.kontakt_metadaten),
       },
     };
   }
@@ -249,7 +249,7 @@ export class Gb3MetadataService extends Gb3ApiService {
       datasets: service.datasets.map(this.extractDatasetDetail),
       serviceType: service.servicetyp,
       description: service.beschreibung,
-      imageUrl: service.image_url ? this.createAbsoluteUrl(service.image_url) : null,
+      imageUrl: service.image_url ? this.createAbsoluteUrl(service.image_url.src.href) : null,
     };
   }
 
@@ -262,7 +262,7 @@ export class Gb3MetadataService extends Gb3ApiService {
         metadata: this.extractContactDetails(product.kontakt_metadaten),
       },
       description: product.beschreibung,
-      imageUrl: product.image_url ? this.createAbsoluteUrl(product.image_url) : null,
+      imageUrl: product.image_url ? this.createAbsoluteUrl(product.image_url.src.href) : null,
       datasets: product.datasets.map(this.extractDatasetDetail),
     };
   }

--- a/src/app/shared/services/apis/gb3/gb3-topics.service.spec.ts
+++ b/src/app/shared/services/apis/gb3/gb3-topics.service.spec.ts
@@ -583,7 +583,7 @@ describe('Gb3TopicsService', () => {
                           href: 'not just a LOTR location',
                           hreflang: 'test',
                         },
-                        type: 'url',
+                        type: 'link',
                       },
                     ],
                     geometry: {
@@ -738,26 +738,32 @@ describe('Gb3TopicsService', () => {
                         {
                           label: 'BFSNr',
                           value: '261',
+                          type: 'text',
                         },
                         {
                           label: 'Nummer',
                           value: 'AU5641',
+                          type: 'text',
                         },
                         {
                           label: 'EGRIS_EGRID',
                           value: 'CH327810999162',
+                          type: 'text',
                         },
                         {
                           label: 'Vollständigkeit',
                           value: 'Vollstaendig',
+                          type: 'text',
                         },
                         {
                           label: 'Fläche [m\u0026sup2;]',
                           value: '2874',
+                          type: 'text',
                         },
                         {
                           label: 'Value might be null',
                           value: null,
+                          type: 'text',
                         },
                         {
                           label: 'A LinkObject',
@@ -765,6 +771,7 @@ describe('Gb3TopicsService', () => {
                             title: 'Amon Amarth',
                             href: 'not just a LOTR location',
                           },
+                          type: 'link',
                         },
                       ],
                       geometry: {
@@ -795,26 +802,32 @@ describe('Gb3TopicsService', () => {
                         {
                           label: 'BFSNr',
                           value: '261',
+                          type: 'text',
                         },
                         {
                           label: 'Qualität',
                           value: 'AV93',
+                          type: 'text',
                         },
                         {
                           label: 'Art',
                           value: 'Gebäude Verwaltung',
+                          type: 'text',
                         },
                         {
                           label: 'GWR_EGID',
                           value: '302019364',
+                          type: 'text',
                         },
                         {
                           label: 'GVZ Nr.',
                           value: 'AU04950',
+                          type: 'text',
                         },
                         {
                           label: 'Geometrie [m\u0026sup2;]',
                           value: '2159.843540479304',
+                          type: 'text',
                         },
                       ],
                       geometry: {
@@ -845,14 +858,17 @@ describe('Gb3TopicsService', () => {
                         {
                           label: 'BFSNr',
                           value: '261',
+                          type: 'text',
                         },
                         {
                           label: 'Name',
                           value: 'Zürich',
+                          type: 'text',
                         },
                         {
                           label: 'Stand AV',
                           value: '11.12.2023',
+                          type: 'text',
                         },
                       ],
                       geometry: undefined,

--- a/src/app/shared/services/apis/gb3/gb3-topics.service.spec.ts
+++ b/src/app/shared/services/apis/gb3/gb3-topics.service.spec.ts
@@ -553,8 +553,8 @@ describe('Gb3TopicsService', () => {
                       },
                       {
                         label: 'Nummer',
-                        value: 'AU5641',
-                        type: 'text',
+                        value: {url: {href: 'https://www.example.com'}, src: {href: 'https://www.example.com'}, alt: 'Text'},
+                        type: 'image',
                       },
                       {
                         label: 'EGRIS_EGRID',
@@ -742,8 +742,8 @@ describe('Gb3TopicsService', () => {
                         },
                         {
                           label: 'Nummer',
-                          value: 'AU5641',
-                          type: 'text',
+                          value: {url: {href: 'https://www.example.com'}, src: {href: 'https://www.example.com'}, alt: 'Text'},
+                          type: 'image',
                         },
                         {
                           label: 'EGRIS_EGRID',

--- a/src/app/shared/services/apis/gb3/gb3-topics.service.spec.ts
+++ b/src/app/shared/services/apis/gb3/gb3-topics.service.spec.ts
@@ -549,34 +549,41 @@ describe('Gb3TopicsService', () => {
                       {
                         label: 'BFSNr',
                         value: 261,
+                        type: 'text',
                       },
                       {
                         label: 'Nummer',
                         value: 'AU5641',
+                        type: 'text',
                       },
                       {
                         label: 'EGRIS_EGRID',
                         value: 'CH327810999162',
+                        type: 'text',
                       },
                       {
                         label: 'Vollständigkeit',
                         value: 'Vollstaendig',
+                        type: 'text',
                       },
                       {
                         label: 'Fläche [m\u0026sup2;]',
                         value: 2874,
+                        type: 'text',
                       },
                       {
                         label: 'Value might be null',
                         value: null,
+                        type: 'text',
                       },
                       {
                         label: 'A LinkObject',
-                        link: {
+                        value: {
                           title: 'Amon Amarth',
                           href: 'not just a LOTR location',
                           hreflang: 'test',
                         },
+                        type: 'url',
                       },
                     ],
                     geometry: {
@@ -613,26 +620,32 @@ describe('Gb3TopicsService', () => {
                       {
                         label: 'BFSNr',
                         value: 261,
+                        type: 'text',
                       },
                       {
                         label: 'Qualität',
                         value: 'AV93',
+                        type: 'text',
                       },
                       {
                         label: 'Art',
                         value: 'Gebäude Verwaltung',
+                        type: 'text',
                       },
                       {
                         label: 'GWR_EGID',
                         value: 302019364,
+                        type: 'text',
                       },
                       {
                         label: 'GVZ Nr.',
                         value: 'AU04950',
+                        type: 'text',
                       },
                       {
                         label: 'Geometrie [m\u0026sup2;]',
                         value: 2159.843540479304,
+                        type: 'text',
                       },
                     ],
                     geometry: {
@@ -669,14 +682,17 @@ describe('Gb3TopicsService', () => {
                       {
                         label: 'BFSNr',
                         value: 261,
+                        type: 'text',
                       },
                       {
                         label: 'Name',
                         value: 'Zürich',
+                        type: 'text',
                       },
                       {
                         label: 'Stand AV',
                         value: '11.12.2023',
+                        type: 'text',
                       },
                     ],
                     geometry: undefined,

--- a/src/app/shared/services/apis/gb3/gb3-topics.service.ts
+++ b/src/app/shared/services/apis/gb3/gb3-topics.service.ts
@@ -379,7 +379,7 @@ export class Gb3TopicsService extends Gb3ApiService {
           label: field.label,
         };
       case 'text':
-        return {type: field.type, value: typeof field.value === 'number' ? field.value.toString() : null, label: field.label};
+        return {type: field.type, value: typeof field.value === 'number' ? field.value.toString() : field.value, label: field.label};
     }
   }
 }

--- a/src/app/shared/services/apis/gb3/gb3-topics.service.ts
+++ b/src/app/shared/services/apis/gb3/gb3-topics.service.ts
@@ -21,6 +21,7 @@ import {
 } from '../../../interfaces/topic.interface';
 import {
   Geometry,
+  Image,
   InfoFeatureField,
   TopicsFeatureInfoDetailData,
   TopicsLegendDetailData,
@@ -369,14 +370,10 @@ export class Gb3TopicsService extends Gb3ApiService {
     };
   }
 
-  private createFeatureInfoFieldValue(field: InfoFeatureField): string | LinkObject | null {
-    if ('link' in field) {
-      return {
-        title: field.link.title,
-        href: field.link.href,
-      };
+  private createFeatureInfoFieldValue(field: InfoFeatureField): string | LinkObject | Image | null {
+    if (typeof field.value === 'number') {
+      return field.value.toString();
     }
-
-    return field.value?.toString() ?? null;
+    return field.value;
   }
 }

--- a/src/app/shared/services/apis/gb3/gb3-topics.service.ts
+++ b/src/app/shared/services/apis/gb3/gb3-topics.service.ts
@@ -371,19 +371,16 @@ export class Gb3TopicsService extends Gb3ApiService {
   }
 
   private createFeatureInfoFieldValue(field: InfoFeatureField): string | LinkObject | Image | null {
-    if (field.value === null) {
-      return null;
-    }
-    if (typeof field.value === 'number') {
-      return field.value.toString();
-    }
-    if (typeof field.value === 'string' || 'alt' in field.value) {
-      return field.value;
-    } else {
-      return {
-        title: field.value.title,
-        href: field.value.href,
-      };
+    switch (field.type) {
+      case 'image':
+        return field.value;
+      case 'link':
+        return {
+          title: field.value.title,
+          href: field.value.href,
+        };
+      case 'text':
+        return typeof field.value === 'number' ? field.value.toString() : null;
     }
   }
 }

--- a/src/app/shared/services/apis/gb3/gb3-topics.service.ts
+++ b/src/app/shared/services/apis/gb3/gb3-topics.service.ts
@@ -31,14 +31,12 @@ import {Gb3ApiService} from './gb3-api.service';
 import {InvalidTimeSliderConfiguration} from '../../../errors/map.errors';
 import {QueryTopic} from '../../../interfaces/query-topic.interface';
 import {ApiGeojsonGeometryToGb3ConverterUtils} from '../../../utils/api-geojson-geometry-to-gb3-converter.utils';
-import {LinkObject} from '../../../interfaces/link-object.interface';
 import {GeometryWithSrs} from '../../../interfaces/geojson-types-with-srs.interface';
 import {HttpClient} from '@angular/common/http';
 import {ConfigService} from '../../config.service';
 import {TIME_SERVICE} from '../../../../app.module';
 import {TimeService} from '../../../interfaces/time-service.interface';
 import {TimeSliderService} from '../../../../map/services/time-slider.service';
-import {Image} from '../../../interfaces/image.interface';
 
 const INACTIVE_STRING_FILTER_VALUE = '';
 const INACTIVE_NUMBER_FILTER_VALUE = -1;
@@ -348,10 +346,7 @@ export class Gb3TopicsService extends Gb3ApiService {
                 return {
                   fid: feature.fid,
                   fields: feature.fields.map((field): FeatureInfoResultFeatureField => {
-                    return {
-                      label: field.label,
-                      value: this.createFeatureInfoFieldValue(field),
-                    };
+                    return this.createFeatureInfoField(field);
                   }),
                   geometry: feature.geometry ? this.convertGeometryToSupportedGeometry(feature.geometry) : undefined,
                 };
@@ -370,17 +365,21 @@ export class Gb3TopicsService extends Gb3ApiService {
     };
   }
 
-  private createFeatureInfoFieldValue(field: InfoFeatureField): string | LinkObject | Image | null {
+  private createFeatureInfoField(field: InfoFeatureField): FeatureInfoResultFeatureField {
     switch (field.type) {
       case 'image':
-        return field.value;
+        return {type: field.type, value: field.value, label: field.label};
       case 'link':
         return {
-          title: field.value.title,
-          href: field.value.href,
+          type: field.type,
+          value: {
+            title: field.value.title,
+            href: field.value.href,
+          },
+          label: field.label,
         };
       case 'text':
-        return typeof field.value === 'number' ? field.value.toString() : null;
+        return {type: field.type, value: typeof field.value === 'number' ? field.value.toString() : null, label: field.label};
     }
   }
 }

--- a/src/app/shared/services/apis/gb3/gb3-topics.service.ts
+++ b/src/app/shared/services/apis/gb3/gb3-topics.service.ts
@@ -371,9 +371,19 @@ export class Gb3TopicsService extends Gb3ApiService {
   }
 
   private createFeatureInfoFieldValue(field: InfoFeatureField): string | LinkObject | Image | null {
+    if (field.value === null) {
+      return null;
+    }
     if (typeof field.value === 'number') {
       return field.value.toString();
     }
-    return field.value;
+    if (typeof field.value === 'string' || 'alt' in field.value) {
+      return field.value;
+    } else {
+      return {
+        title: field.value.title,
+        href: field.value.href,
+      };
+    }
   }
 }

--- a/src/app/shared/services/apis/gb3/gb3-topics.service.ts
+++ b/src/app/shared/services/apis/gb3/gb3-topics.service.ts
@@ -21,7 +21,6 @@ import {
 } from '../../../interfaces/topic.interface';
 import {
   Geometry,
-  Image,
   InfoFeatureField,
   TopicsFeatureInfoDetailData,
   TopicsLegendDetailData,
@@ -39,6 +38,7 @@ import {ConfigService} from '../../config.service';
 import {TIME_SERVICE} from '../../../../app.module';
 import {TimeService} from '../../../interfaces/time-service.interface';
 import {TimeSliderService} from '../../../../map/services/time-slider.service';
+import {Image} from '../../../interfaces/image.interface';
 
 const INACTIVE_STRING_FILTER_VALUE = '';
 const INACTIVE_NUMBER_FILTER_VALUE = -1;


### PR DESCRIPTION
Adds images to the feature info. 
Links to working examples: 
http://localhost:4200/s/7101c634-b835-47ea-98e3-7951257c03a3
http://localhost:4200/s/ce842c54-382a-4720-bfed-6373c1f8328a (need to be looged in)
In some cases, the src they send is just a link to a hosting platform an thus cannot display an image. They are working on it (see [Ticket](https://jira-geo.zh.ch/browse/GB3-1390)