### PR TITLE
Feature/gb3 1675 geometadata reduced content

### DIFF
--- a/src/app/shared/models/gb3-api-generated.interfaces.ts
+++ b/src/app/shared/models/gb3-api-generated.interfaces.ts
@@ -165,7 +165,23 @@ export interface MetadataDataset {
 }
 
 export interface MetadataDatasets {
-  datasets: Dataset[];
+  datasets: {
+    /** UUID */
+    uuid: string;
+    /** Kurzbeschreibung */
+    kurzbeschreibung: string;
+    /** Name des Geodatensatzes */
+    name: string;
+    /** Kontakt: Zuständig für Geometadaten */
+    kontakt_metadaten: {
+      /** Amt */
+      amt: string;
+    };
+    /** Abgabeformate */
+    abgabeformate: string[];
+    /** Verfügbarkeit OGD/NOGD */
+    ogd: boolean;
+  }[];
 }
 
 export interface MetadataGeoshopProducts {
@@ -182,7 +198,19 @@ export interface MetadataMap {
 }
 
 export interface MetadataMaps {
-  maps: Map[];
+  maps: {
+    /** Map UUID */
+    uuid: string;
+    /** Beschreibung der Karte */
+    beschreibung: string;
+    /** Kartenname */
+    name: string;
+    /** Kontakt: Zuständig für Geometadaten */
+    kontakt_metadaten: {
+      /** Amt */
+      amt: string;
+    };
+  }[];
 }
 
 export interface MetadataProduct {
@@ -190,7 +218,19 @@ export interface MetadataProduct {
 }
 
 export interface MetadataProducts {
-  products: Product[];
+  products: {
+    /** Product UUID */
+    uuid: string;
+    /** Beschreibung des Geoproduktes */
+    beschreibung: string;
+    /** Name des Geodatenprodukts */
+    name: string;
+    /** Kontakt: Zuständig für Geometadaten */
+    kontakt_metadaten: {
+      /** Amt */
+      amt: string;
+    };
+  }[];
 }
 
 export interface MetadataService {
@@ -198,7 +238,19 @@ export interface MetadataService {
 }
 
 export interface MetadataServices {
-  services: Service[];
+  services: {
+    /** Service UUID */
+    uuid: string;
+    /** Beschreibung des Geodienstes */
+    beschreibung: string;
+    /** Name des Geodienstes */
+    name: string;
+    /** Kontakt: Zuständig für Geometadaten */
+    kontakt_metadaten: {
+      /** Amt */
+      amt: string;
+    };
+  }[];
 }
 
 export interface MunicipalitiesList {

--- a/src/app/shared/services/apis/gb3/gb3-metadata.service.ts
+++ b/src/app/shared/services/apis/gb3/gb3-metadata.service.ts
@@ -81,14 +81,12 @@ export class Gb3MetadataService extends Gb3ApiService {
         result.datasets.map((dataset) => {
           const {
             uuid: guid,
-            shortDescription,
+            kurzbeschreibung: shortDescription,
             name,
-            contact: {
-              metadata: {department},
-            },
-            outputFormat,
+            kontakt_metadaten: {amt: department},
+            abgabeformate: outputFormat,
             ogd,
-          } = this.transformDatasetsDetailDataToDatasetMetadata(dataset);
+          } = dataset;
           return new DatasetOverviewMetadataItem(guid, name, shortDescription, department, outputFormat, ogd);
         }),
       ),
@@ -103,12 +101,10 @@ export class Gb3MetadataService extends Gb3ApiService {
         result.products.map((product) => {
           const {
             uuid: guid,
-            description,
+            beschreibung: description,
             name,
-            contact: {
-              metadata: {department},
-            },
-          } = this.transformProductDetailToProductMetadata(product);
+            kontakt_metadaten: {amt: department},
+          } = product;
           return new ProductOverviewMetadataItem(guid, name, description, department);
         }),
       ),
@@ -123,12 +119,10 @@ export class Gb3MetadataService extends Gb3ApiService {
         result.maps.map((mapMetadata) => {
           const {
             uuid: guid,
-            description,
+            beschreibung: description,
             name,
-            contact: {
-              geodata: {department},
-            },
-          } = this.transformMapsDetailToMapMetadata(mapMetadata);
+            kontakt_metadaten: {amt: department},
+          } = mapMetadata;
           return new MapOverviewMetadataItem(guid, name, description, department);
         }),
       ),
@@ -143,12 +137,10 @@ export class Gb3MetadataService extends Gb3ApiService {
         result.services.map((service) => {
           const {
             uuid: guid,
-            description,
+            beschreibung: description,
             name,
-            contact: {
-              metadata: {department},
-            },
-          } = this.transformServicesDetailToServiceMetadata(service);
+            kontakt_metadaten: {amt: department},
+          } = service;
           return new ServiceOverviewMetadataItem(guid, name, description, department);
         }),
       ),


### PR DESCRIPTION
Depends on #10 
Apply the changes needed to use the Metadata endpoint with reduced data. 
Note: The images in the "Karten"-Detail page are currently not displayed because the do not work on V3 yet, Mathias Manz is working on it