### PR TITLE
fix wrong display of timeslider of parameter type and with range

### DIFF
--- a/src/app/map/components/time-slider/time-slider.component.html
+++ b/src/app/map/components/time-slider/time-slider.component.html
@@ -2,7 +2,7 @@
   class="time-slider"
   title="{{ timeSliderConfiguration.name }}"
   description="{{ timeSliderConfiguration.description }}"
-  [value]="timeExtentDisplay | timeExtentToString: timeSliderConfiguration.dateFormat : hasSimpleCurrentValue"
+  [value]="timeExtent | timeExtentToString: timeSliderConfiguration.dateFormat : hasSimpleCurrentValue"
   [minValue]="availableDates[effectiveMinimumDateIndex] | dateToString: timeSliderConfiguration.dateFormat"
   [maxValue]="availableDates[effectiveMaximumDateIndex] | dateToString: timeSliderConfiguration.dateFormat"
   [overwriteFooter]="hasDatePicker"
@@ -10,26 +10,11 @@
   <ng-container content>
     <mat-slider [min]="effectiveMinimumDateIndex" [max]="effectiveMaximumDateIndex" [step]="1" color="primary" class="time-slider__slider">
       <ng-container *ngIf="this.timeSliderConfiguration.range; else multiSlider">
-        <input
-          matSliderThumb
-          (valueChange)="setValidTimeExtent(true)"
-          (input)="updateTimeExtentDisplay()"
-          [(ngModel)]="firstSliderPosition"
-        />
+        <input matSliderThumb (valueChange)="setValidTimeExtent(true)" [(ngModel)]="firstSliderPosition" />
       </ng-container>
       <ng-template #multiSlider>
-        <input
-          matSliderStartThumb
-          (valueChange)="setValidTimeExtent(true)"
-          (input)="updateTimeExtentDisplay()"
-          [(ngModel)]="firstSliderPosition"
-        />
-        <input
-          matSliderEndThumb
-          (valueChange)="setValidTimeExtent(false)"
-          (input)="updateTimeExtentDisplay()"
-          [(ngModel)]="secondSliderPosition"
-        />
+        <input matSliderStartThumb (valueChange)="setValidTimeExtent(true)" [(ngModel)]="firstSliderPosition" />
+        <input matSliderEndThumb (valueChange)="setValidTimeExtent(false)" [(ngModel)]="secondSliderPosition" />
       </ng-template>
     </mat-slider>
   </ng-container>

--- a/src/app/map/components/time-slider/time-slider.component.ts
+++ b/src/app/map/components/time-slider/time-slider.component.ts
@@ -32,7 +32,6 @@ export class TimeSliderComponent implements OnInit, OnChanges {
   public secondSliderPosition?: number;
 
   public timeExtent!: TimeExtent;
-  public timeExtentDisplay!: TimeExtent;
 
   public effectiveMinimumDateIndex!: number;
   public effectiveMaximumDateIndex!: number;
@@ -55,7 +54,6 @@ export class TimeSliderComponent implements OnInit, OnChanges {
     this.effectiveMinimumDateIndex = 0;
     this.effectiveMaximumDateIndex = this.availableDates.length - 1;
     this.timeExtent = {start: this.initialTimeExtent.start, end: this.initialTimeExtent.end};
-    this.timeExtentDisplay = {start: this.initialTimeExtent.start, end: this.initialTimeExtent.end};
     this.firstSliderPosition = this.findPositionOfDate(this.timeExtent.start) ?? 0;
     this.secondSliderPosition = this.timeSliderConfiguration.range ? undefined : this.findPositionOfDate(this.timeExtent.end);
     this.hasSimpleCurrentValue = this.isStringSingleTimeUnitRange(this.timeSliderConfiguration.range);
@@ -76,7 +74,6 @@ export class TimeSliderComponent implements OnInit, OnChanges {
       this.timeExtent = {start, end};
       this.firstSliderPosition = this.findPositionOfDate(start) ?? 0;
       this.secondSliderPosition = this.timeSliderConfiguration.range ? undefined : this.findPositionOfDate(end);
-      this.updateTimeExtentDisplay();
     }
   }
 
@@ -119,15 +116,6 @@ export class TimeSliderComponent implements OnInit, OnChanges {
       this.timeExtent = newValidatedTimeExtent;
       this.changeTimeExtentEvent.emit(this.timeExtent);
     }
-    // overwrite the display of the timeslider in any case to avoid display of invalid ranges such as 1700-1700
-    this.timeExtentDisplay = newValidatedTimeExtent;
-  }
-
-  public updateTimeExtentDisplay() {
-    this.timeExtentDisplay = {
-      start: this.availableDates[this.firstSliderPosition],
-      end: this.secondSliderPosition ? this.availableDates[this.secondSliderPosition] : this.availableDates[this.firstSliderPosition],
-    };
   }
 
   public yearOrMonthSelected(


### PR DESCRIPTION
Timesliders of sourceType `paramter `with the property `range `(There is currently only one of them)  were not properly labelled. 

The end date of the range was just set to be the same as the start date of the range. 

While fixing this, I also found that the `timeExtentDisplay `was not really necessary. I had added this for an earlier change, but I could not find a scenario where it was needed, so I removed it. MAybe test this extra thoroughly in case I missed something there.

To test, log in with the gb3-user-public-view account and add the favourite 'Timeslider' or 'TS2'