### PR TITLE
Show the legend/ info for the correct layer

### DIFF
--- a/src/app/state/map/effects/active-map-item.effects.ts
+++ b/src/app/state/map/effects/active-map-item.effects.ts
@@ -372,11 +372,7 @@ export class ActiveMapItemEffects {
         return produce(existingMapItem, (draft) => {
           draft.settings.timeSliderExtent = timeExtent;
           draft.settings.layers.forEach((layer) => {
-            const isVisible = this.timeSliderService.isLayerVisible(
-              layer,
-              existingMapItem.settings.timeSliderConfiguration,
-              existingMapItem.settings.timeSliderExtent,
-            );
+            const isVisible = this.timeSliderService.isLayerVisible(layer, existingMapItem.settings.timeSliderConfiguration, timeExtent);
             if (isVisible !== undefined) {
               layer.visible = isVisible;
             }


### PR DESCRIPTION
We incorrectly updated the layer that is visible, which resulted in a feature info or legend request for the wrong layer (the one selected before the currently selected one)