### PR TITLE
GB3-1662: Fixed Renovate assignees and added confidence badges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
-  "extends": ["config:recommended"],
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "assignees": ["team:gb3-maintainer"],
+  "extends": ["config:recommended", "mergeConfidence:all-badges"],
   "reviewers": ["team:gb3-maintainer"],
   "packageRules": [
     {


### PR DESCRIPTION
Modified `renovate.json` by removing the assignees and added confidence badges.