### PR TITLE
Improved renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
         "@schematics/angular",
         "angular-oauth2-oidc",
         "@ngrx/",
-        "typescript"
+        "zone.js"
       ]
     },
     {


### PR DESCRIPTION
Modified `renovate.json` by removing `typescript` from the _angular_ group and instead added `zone.js`.