### PR TITLE
Make console.log an error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,7 +137,7 @@ export default tseslint.config(
       '@typescript-eslint/switch-exhaustiveness-check': 'error',
 
       'no-console': [
-        'warn',
+        'error',
         {
           allow: ['warn', 'error'],
         },

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -157,6 +157,7 @@ export class AuthService {
     if (event instanceof OAuthErrorEvent) {
       console.error('OAuthErrorEvent Object:', event);
     } else {
+      //eslint-disable-next-line no-console -- Debugging OAuth events in development mode
       console.log('OAuthEvent Object:', event);
     }
   }


### PR DESCRIPTION
This PR adds `console.log` as en eslint error.
I added an exclusion for the only place where we use `console.log`, with an explanation why this is needed there.

We still allow `console.warn` and `console.error`, since they are used in some places. We could think of adding them as well; however, I think what we want to capture are accidental leftovers from debugging which will almost always be `console.log`

CC @wendlans 