### PR TITLE
remove pointer events all as it is set in the search-bar.component.scss

### DIFF
--- a/src/app/map/components/search-window/search-window.component.scss
+++ b/src/app/map/components/search-window/search-window.component.scss
@@ -9,8 +9,6 @@
 .search-window {
   @include mixins.map-element-box-shadow;
   width: map-layout-variables.$search-window-width;
-  background-color: ktzh-variables.$zh-background-color;
-  pointer-events: all;
   overflow: hidden;
   height: search-bar-variables.$search-bar-height;
 }


### PR DESCRIPTION
Resolves issue that did not allow to interact with map underneath the search bar