### PR TITLE
GB3-1760: Implement custom scalebar

### DIFF
--- a/src/app/map/components/map-controls/map-controls.component.html
+++ b/src/app/map/components/map-controls/map-controls.component.html
@@ -6,10 +6,11 @@
     ></basemap-selector>
     <div class="map-controls__inputs__bottom">
       <div
-        class="map-controls__inputs__bottom__scale-bar-container"
+        class="map-controls__inputs__bottom__scale-bar-containerold"
         #scaleBarContainer
         [ngClass]="{'map-controls__map-element--hidden': mapUiState?.hideUiElements}"
       ></div>
+      <scale-bar [ngClass]="{'map-controls__map-element--hidden': mapUiState?.hideUiElements}"></scale-bar>
       <coordinate-scale-inputs
         class="map-controls__inputs__bottom__data-inputs"
         [ngClass]="{'map-controls__map-element--hidden': mapUiState?.hideUiElements}"

--- a/src/app/map/components/map-controls/map-controls.component.html
+++ b/src/app/map/components/map-controls/map-controls.component.html
@@ -5,11 +5,6 @@
       [ngClass]="{'map-controls__map-element--hidden': mapUiState?.hideUiElements}"
     ></basemap-selector>
     <div class="map-controls__inputs__bottom">
-      <div
-        class="map-controls__inputs__bottom__scale-bar-containerold"
-        #scaleBarContainer
-        [ngClass]="{'map-controls__map-element--hidden': mapUiState?.hideUiElements}"
-      ></div>
       <scale-bar [ngClass]="{'map-controls__map-element--hidden': mapUiState?.hideUiElements}"></scale-bar>
       <coordinate-scale-inputs
         class="map-controls__inputs__bottom__data-inputs"

--- a/src/app/map/components/map-controls/map-controls.component.scss
+++ b/src/app/map/components/map-controls/map-controls.component.scss
@@ -34,11 +34,6 @@
       align-items: flex-end;
       gap: 12px;
 
-      .map-controls__inputs__bottom__scale-bar-containerold {
-        border-radius: ktzh-variables.$zh-border-radius;
-        font-family: ktzh-variables.$zh-font-family;
-      }
-
       .map-controls__inputs__bottom__data-inputs {
         @include mixins.map-element-box-shadow;
         display: block;

--- a/src/app/map/components/map-controls/map-controls.component.scss
+++ b/src/app/map/components/map-controls/map-controls.component.scss
@@ -34,10 +34,11 @@
       align-items: flex-end;
       gap: 12px;
 
-      .map-controls__inputs__bottom__scale-bar-container {
+      .map-controls__inputs__bottom__scale-bar-containerold {
         border-radius: ktzh-variables.$zh-border-radius;
         font-family: ktzh-variables.$zh-font-family;
       }
+
       .map-controls__inputs__bottom__data-inputs {
         @include mixins.map-element-box-shadow;
         display: block;

--- a/src/app/map/components/map-controls/map-controls.component.ts
+++ b/src/app/map/components/map-controls/map-controls.component.ts
@@ -1,4 +1,4 @@
-import {AfterViewInit, Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
+import {Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {Subscription, tap} from 'rxjs';
 import {ScreenMode} from 'src/app/shared/types/screen-size.type';
@@ -14,7 +14,7 @@ import {MapService} from '../../interfaces/map.service';
   styleUrls: ['./map-controls.component.scss'],
   standalone: false,
 })
-export class MapControlsComponent implements OnInit, OnDestroy, AfterViewInit {
+export class MapControlsComponent implements OnInit, OnDestroy {
   @ViewChild('scaleBarContainer', {static: true}) private scaleBarContainerRef!: ElementRef;
 
   public screenMode: ScreenMode = 'regular';
@@ -35,10 +35,6 @@ export class MapControlsComponent implements OnInit, OnDestroy, AfterViewInit {
 
   public ngOnDestroy() {
     this.subscriptions.unsubscribe();
-  }
-
-  public ngAfterViewInit() {
-    this.mapService.assignScaleBarElement(this.scaleBarContainerRef.nativeElement);
   }
 
   private initSubscriptions() {

--- a/src/app/map/components/map-controls/scale-bar/scale-bar.component.html
+++ b/src/app/map/components/map-controls/scale-bar/scale-bar.component.html
@@ -1,0 +1,5 @@
+<div #scaleBar class="scale-bar" [ngClass]="{'scale-bar--hidden': !scaleBarLabel }">
+  <span class="scale-bar__label">
+    <strong>{{ scaleBarLabel }}</strong>
+  </span>
+</div>

--- a/src/app/map/components/map-controls/scale-bar/scale-bar.component.scss
+++ b/src/app/map/components/map-controls/scale-bar/scale-bar.component.scss
@@ -1,0 +1,20 @@
+@use 'variables/ktzh-design-variables' as ktzh-variables;
+
+.scale-bar {
+  border: 2px solid black;
+  border-top: none;
+  height: 20px;
+  box-sizing: border-box;
+  background-color: rgba(255,255,255, 0.5);
+
+  &--hidden {
+    display: none;
+  }
+
+  .scale-bar__label {
+    padding-left: 4px;
+    font-family: ktzh-variables.$zh-font-family;
+    font-size: small;
+    position: relative;
+  }
+}

--- a/src/app/map/components/map-controls/scale-bar/scale-bar.component.ts
+++ b/src/app/map/components/map-controls/scale-bar/scale-bar.component.ts
@@ -1,17 +1,10 @@
 import {AfterViewInit, Component, ElementRef, OnDestroy, ViewChild} from '@angular/core';
 import {Store} from '@ngrx/store';
 import {filter, Subscription, tap} from 'rxjs';
-import {selectReferenceDistanceInMeters} from 'src/app/state/map/reducers/map-config.reducer';
-import {MapConstants} from '../../../../shared/constants/map.constants';
 import {NgClass} from '@angular/common';
+import {selectScaleBarConfig} from '../../../../state/map/selectors/scale-bar-config.selector';
+import {ScaleBarConfig} from '../../../../shared/interfaces/scale-bar-config.interface';
 
-/**
- * A scale bar component that displays a scale bar based on the reference distance in meters. Its counterpart is in the mapservice that
- * needs to calculate the reference distance in meters by a set of know pixel coordinates.
- *
- * The glue for these components is the MapConstants.MAX_SCALE_BAR_WIDTH_PX constant that defines the maximum width of the scale bar,
- * which can then be used to calculate the actual ration given the reference distance of said pixel length.
- */
 @Component({
   selector: 'scale-bar',
   templateUrl: './scale-bar.component.html',
@@ -22,22 +15,19 @@ export class ScaleBarComponent implements AfterViewInit, OnDestroy {
   protected scaleBarLabel: string | undefined;
   @ViewChild('scaleBar', {static: true}) private scaleBar!: ElementRef;
   private readonly subscriptions: Subscription = new Subscription();
-  private referenceDistanceInMeters$ = this.store.select(selectReferenceDistanceInMeters);
+  private scaleBarConfig$ = this.store.select(selectScaleBarConfig);
 
   constructor(private readonly store: Store) {}
 
   public ngAfterViewInit() {
     // we use afterViewInit because then we can be sure that #scaleBar is available
     this.subscriptions.add(
-      this.referenceDistanceInMeters$
+      this.scaleBarConfig$
         .pipe(
-          filter((distanceInMeters): distanceInMeters is number => distanceInMeters !== undefined),
-          tap((distanceInMeters) => {
-            if (distanceInMeters >= 1) {
-              this.updateWithRoundedDistance(distanceInMeters);
-            } else {
-              this.updateWithCentimeters(distanceInMeters);
-            }
+          filter((scaleBarConfig): scaleBarConfig is ScaleBarConfig => scaleBarConfig !== undefined),
+          tap(({scaleBarWidthInPx, value, unit}) => {
+            this.scaleBar.nativeElement.style.width = `${scaleBarWidthInPx}px`;
+            this.scaleBarLabel = `${value} ${unit}`;
           }),
         )
         .subscribe(),
@@ -46,38 +36,5 @@ export class ScaleBarComponent implements AfterViewInit, OnDestroy {
 
   public ngOnDestroy() {
     this.subscriptions.unsubscribe();
-  }
-
-  /**
-   * Updates the scale bar to centimeters by finding the closes match and then calculating the ratio.
-   */
-  private updateWithCentimeters(distanceInMeters: number) {
-    const breaks = [50, 20, 10, 5, 2, 1];
-    const centimeters = Math.round(distanceInMeters * 100); // Convert meters to cm
-    const snappedCentimeter = breaks.find((b) => centimeters >= b) || 1; // Find closest match
-    const ratio = snappedCentimeter / (distanceInMeters * 100);
-
-    this.updateScaleBarWidth(ratio);
-    this.scaleBarLabel = `${snappedCentimeter} cm`;
-  }
-
-  /**
-   * Updates the scale bar to meters by rounding to common scale values and calculating the correct ratio.
-   * This is adapted from Leaflet's L.Control.Scale._getRoundNum method
-   * (https://github.com/Leaflet/Leaflet/blob/main/src/control/Control.Scale.js#L117)
-   */
-  private updateWithRoundedDistance(distanceInMeters: number) {
-    const pow10 = Math.pow(10, `${Math.floor(distanceInMeters)}`.length - 1);
-    let d = distanceInMeters / pow10;
-    d = d >= 10 ? 10 : d >= 5 ? 5 : d >= 3 ? 3 : d >= 2 ? 2 : 1;
-    const meters = pow10 * d;
-    const ratio = meters / distanceInMeters;
-
-    this.updateScaleBarWidth(ratio);
-    this.scaleBarLabel = meters >= 1000 ? `${meters / 1000} km` : `${meters} m`;
-  }
-
-  private updateScaleBarWidth(ratio: number) {
-    this.scaleBar.nativeElement.style.width = `${Math.round(MapConstants.MAX_SCALE_BAR_WIDTH_PX * ratio)}px`;
   }
 }

--- a/src/app/map/components/map-controls/scale-bar/scale-bar.component.ts
+++ b/src/app/map/components/map-controls/scale-bar/scale-bar.component.ts
@@ -1,0 +1,83 @@
+import {AfterViewInit, Component, ElementRef, OnDestroy, ViewChild} from '@angular/core';
+import {Store} from '@ngrx/store';
+import {filter, Subscription, tap} from 'rxjs';
+import {selectReferenceDistanceInMeters} from 'src/app/state/map/reducers/map-config.reducer';
+import {MapConstants} from '../../../../shared/constants/map.constants';
+import {NgClass} from '@angular/common';
+
+/**
+ * A scale bar component that displays a scale bar based on the reference distance in meters. Its counterpart is in the mapservice that
+ * needs to calculate the reference distance in meters by a set of know pixel coordinates.
+ *
+ * The glue for these components is the MapConstants.MAX_SCALE_BAR_WIDTH_PX constant that defines the maximum width of the scale bar,
+ * which can then be used to calculate the actual ration given the reference distance of said pixel length.
+ */
+@Component({
+  selector: 'scale-bar',
+  templateUrl: './scale-bar.component.html',
+  styleUrls: ['./scale-bar.component.scss'],
+  imports: [NgClass],
+})
+export class ScaleBarComponent implements AfterViewInit, OnDestroy {
+  protected scaleBarLabel: string | undefined;
+  @ViewChild('scaleBar', {static: true}) private scaleBar!: ElementRef;
+  private readonly subscriptions: Subscription = new Subscription();
+  private referenceDistanceInMeters$ = this.store.select(selectReferenceDistanceInMeters);
+
+  constructor(private readonly store: Store) {}
+
+  public ngAfterViewInit() {
+    // we use afterViewInit because then we can be sure that #scaleBar is available
+    this.subscriptions.add(
+      this.referenceDistanceInMeters$
+        .pipe(
+          filter((distanceInMeters): distanceInMeters is number => distanceInMeters !== undefined),
+          tap((distanceInMeters) => {
+            if (distanceInMeters >= 1) {
+              this.updateWithRoundedDistance(distanceInMeters);
+            } else {
+              this.updateWithCentimeters(distanceInMeters);
+            }
+          }),
+        )
+        .subscribe(),
+    );
+  }
+
+  public ngOnDestroy() {
+    this.subscriptions.unsubscribe();
+  }
+
+  /**
+   * Updates the scale bar to centimeters by finding the closes match and then calculating the ratio.
+   */
+  private updateWithCentimeters(distanceInMeters: number) {
+    const breaks = [50, 20, 10, 5, 2, 1];
+    const centimeters = Math.round(distanceInMeters * 100); // Convert meters to cm
+    const snappedCentimeter = breaks.find((b) => centimeters >= b) || 1; // Find closest match
+    const ratio = snappedCentimeter / (distanceInMeters * 100);
+
+    this.updateScaleBarWidth(ratio);
+    this.scaleBarLabel = `${snappedCentimeter} cm`;
+  }
+
+  /**
+   * Updates the scale bar to meters by rounding to common scale values and calculating the correct ratio.
+   * This is adapted from Leaflet's L.Control.Scale._getRoundNum method
+   * (https://github.com/Leaflet/Leaflet/blob/main/src/control/Control.Scale.js#L117)
+   */
+  private updateWithRoundedDistance(distanceInMeters: number) {
+    const pow10 = Math.pow(10, `${Math.floor(distanceInMeters)}`.length - 1);
+    let d = distanceInMeters / pow10;
+    d = d >= 10 ? 10 : d >= 5 ? 5 : d >= 3 ? 3 : d >= 2 ? 2 : 1;
+    const meters = pow10 * d;
+    const ratio = meters / distanceInMeters;
+
+    this.updateScaleBarWidth(ratio);
+    this.scaleBarLabel = meters >= 1000 ? `${meters / 1000} km` : `${meters} m`;
+  }
+
+  private updateScaleBarWidth(ratio: number) {
+    this.scaleBar.nativeElement.style.width = `${Math.round(MapConstants.MAX_SCALE_BAR_WIDTH_PX * ratio)}px`;
+  }
+}

--- a/src/app/map/interfaces/map.service.ts
+++ b/src/app/map/interfaces/map.service.ts
@@ -17,9 +17,6 @@ export interface MapService extends AddToMapVisitor {
   /** Assigns the map to an element on the HTML */
   assignMapElement(container: HTMLDivElement): void;
 
-  /** Assigns the scale bar to an element on the HTML */
-  assignScaleBarElement(container: HTMLDivElement): void;
-
   /** Sets the scale of the whole map */
   setScale(scale: number): void;
 

--- a/src/app/map/map.module.ts
+++ b/src/app/map/map.module.ts
@@ -104,6 +104,7 @@ import {GenericUnorderedListComponent} from '../shared/components/lists/generic-
 import {SearchResultIdentifierDirective} from '../shared/directives/search-result-identifier.directive';
 import {SearchBarComponent} from '../shared/components/search/search-bar/search-bar.component';
 import {SearchInputComponent} from '../shared/components/search/search-input.component';
+import {ScaleBarComponent} from './components/map-controls/scale-bar/scale-bar.component';
 
 @NgModule({
   providers: [provideCharts(withDefaultRegisterables())],
@@ -217,6 +218,7 @@ import {SearchInputComponent} from '../shared/components/search/search-input.com
     SearchResultIdentifierDirective,
     SearchBarComponent,
     SearchInputComponent,
+    ScaleBarComponent,
   ],
   exports: [
     LegendOverlayComponent,

--- a/src/app/map/services/esri-services/esri-map.service.ts
+++ b/src/app/map/services/esri-services/esri-map.service.ts
@@ -979,7 +979,6 @@ export class EsriMapService implements MapService, OnDestroy {
    * Calculates the reference distance in meters for the scale bar. What we do is that we calculate the distance between two pixel
    * coordinates which have the same y coordinate (half of the screen heigt) and as x use 0 and the reference width. This way, we get a
    * distance which is known, which can be used by the scale bar to calculate its width.
-   * @private
    */
   private calculateReferenceDistanceInMeters(): number {
     const screenHeight = this.mapView.height / 2;

--- a/src/app/map/services/esri-services/esri-map.service.ts
+++ b/src/app/map/services/esri-services/esri-map.service.ts
@@ -53,7 +53,6 @@ import {ZoomExtentMissing} from './errors/esri.errors';
 import {SymbolUnion} from '@arcgis/core/unionTypes';
 import {hasNonNullishProperty} from './type-guards/esri-nullish.type-guard';
 import Transformation from '@arcgis/core/geometry/operators/support/Transformation';
-import ScaleBar from '@arcgis/core/widgets/ScaleBar';
 import KMLLayer from '@arcgis/core/layers/KMLLayer';
 import Point from '@arcgis/core/geometry/Point';
 import SpatialReference from '@arcgis/core/geometry/SpatialReference';
@@ -66,6 +65,7 @@ import MapView from '@arcgis/core/views/MapView';
 import TileInfo from '@arcgis/core/layers/support/TileInfo';
 import EsriMap from '@arcgis/core/Map';
 import {EsriLoadStatus} from './types/esri-load-status.type';
+import * as distanceOperator from '@arcgis/core/geometry/operators/distanceOperator.js';
 import GraphicHit = __esri.GraphicHit;
 
 const DEFAULT_POINT_ZOOM_EXTENT_SCALE = 750;
@@ -83,7 +83,6 @@ enum EsriMouseButtonType {
   providedIn: 'root',
 })
 export class EsriMapService implements MapService, OnDestroy {
-  private scaleBar?: ScaleBar;
   private effectiveMaxZoom = 23;
   private effectiveMinZoom = 0;
   private effectiveMinScale = 0;
@@ -303,13 +302,6 @@ export class EsriMapService implements MapService, OnDestroy {
 
   public assignMapElement(container: HTMLDivElement) {
     this.mapView.container = container;
-  }
-
-  public assignScaleBarElement(container: HTMLDivElement) {
-    if (this.scaleBar) {
-      this.scaleBar.destroy();
-    }
-    this.scaleBar = new ScaleBar({view: this.mapView, container: container, unit: 'metric'});
   }
 
   public setOpacity(opacity: number, mapItem: ActiveMapItem): void {
@@ -836,10 +828,22 @@ export class EsriMapService implements MapService, OnDestroy {
     });
   }
 
+  private updateReferenceDistance() {
+    const referenceDistanceInMeters = this.calculateReferenceDistanceInMeters();
+    this.store.dispatch(MapConfigActions.setReferenceDistance({referenceDistanceInMeters}));
+  }
+
   private attachMapViewListeners() {
     reactiveUtils.when(
       () => this.mapView.stationary,
       () => this.updateMapConfig(),
+    );
+
+    // ensure that the reference distance is calculated after the map is ready, since the scale listener only fires after the first change
+    reactiveUtils.whenOnce(() => this.mapView.ready).then(() => this.updateReferenceDistance());
+    reactiveUtils.watch(
+      () => this.mapView.scale,
+      () => this.updateReferenceDistance(),
     );
 
     reactiveUtils.on(
@@ -969,6 +973,20 @@ export class EsriMapService implements MapService, OnDestroy {
     const {center, scale} = this.mapView;
     const {x, y} = this.transformationService.transform(center);
     this.store.dispatch(MapConfigActions.setMapExtent({x, y, scale}));
+  }
+
+  /**
+   * Calculates the reference distance in meters for the scale bar. What we do is that we calculate the distance between two pixel
+   * coordinates which have the same y coordinate (half of the screen heigt) and as x use 0 and the reference width. This way, we get a
+   * distance which is known, which can be used by the scale bar to calculate its width.
+   * @private
+   */
+  private calculateReferenceDistanceInMeters(): number {
+    const screenHeight = this.mapView.height / 2;
+    const pointA = this.mapView.toMap({x: 0, y: screenHeight});
+    const pointB = this.mapView.toMap({x: MapConstants.MAX_SCALE_BAR_WIDTH_PX, y: screenHeight});
+
+    return distanceOperator.execute(pointA, pointB, {unit: 'meters'});
   }
 
   private switchBasemap(basemapId: string) {

--- a/src/app/map/services/esri-services/esri-map.service.ts
+++ b/src/app/map/services/esri-services/esri-map.service.ts
@@ -977,7 +977,7 @@ export class EsriMapService implements MapService, OnDestroy {
 
   /**
    * Calculates the reference distance in meters for the scale bar. What we do is that we calculate the distance between two pixel
-   * coordinates which have the same y coordinate (half of the screen heigt) and as x use 0 and the reference width. This way, we get a
+   * coordinates which have the same y coordinate (half of the screen height) and as x use 0 and the reference width. This way, we get a
    * distance which is known, which can be used by the scale bar to calculate its width.
    */
   private calculateReferenceDistanceInMeters(): number {

--- a/src/app/shared/configs/map.config.ts
+++ b/src/app/shared/configs/map.config.ts
@@ -26,4 +26,5 @@ export const defaultMapConfig: MapConfigState = {
   initialMapPadding: MapConstants.INITIAL_MAP_PADDING,
   initialMapPaddingMobile: MapConstants.INITIAL_MAP_PADDING_MOBILE,
   initialBoundingBox: MapConstants.KT_ZURICH_BOUNDING_BOX,
+  referenceDistanceInMeters: undefined,
 };

--- a/src/app/shared/constants/map.constants.ts
+++ b/src/app/shared/constants/map.constants.ts
@@ -17,6 +17,7 @@ export class MapConstants {
   public static readonly BELONGS_TO_IDENTIFIER = '__belongsTo';
   public static readonly TOOL_IDENTIFIER = '__tool';
   public static readonly TEXT_DRAWING_MAX_LENGTH = 50;
+  public static readonly MAX_SCALE_BAR_WIDTH_PX = 150;
 
   /**
    * Query params that are removed upon loading the initial map configuration.

--- a/src/app/shared/interfaces/scale-bar-config.interface.ts
+++ b/src/app/shared/interfaces/scale-bar-config.interface.ts
@@ -1,0 +1,5 @@
+export interface ScaleBarConfig {
+  scaleBarWidthInPx: number;
+  value: number;
+  unit: 'km' | 'm' | 'cm';
+}

--- a/src/app/state/map/actions/map-config.actions.ts
+++ b/src/app/state/map/actions/map-config.actions.ts
@@ -15,6 +15,7 @@ export const MapConfigActions = createActionGroup({
       initialMaps: string[];
     }>(),
     'Set Map Extent': props<Coordinate & {scale: number}>(),
+    'Set Reference Distance': props<{referenceDistanceInMeters: number}>(),
     'Set Map Center And Draw Highlight': props<{center: PointWithSrs}>(),
     'Set Ready': props<{calculatedMinScale: number; calculatedMaxScale: number}>(),
     'Set Scale': props<{scale: number}>(),

--- a/src/app/state/map/reducers/map-config.reducer.spec.ts
+++ b/src/app/state/map/reducers/map-config.reducer.spec.ts
@@ -74,7 +74,7 @@ describe('MapConfig Reducer', () => {
     it('sets the map rotation to the incoming value', () => {
       const expectedRotation = 42;
       const actionFloored = MapConfigActions.setRotation({rotation: expectedRotation});
-      const state = reducer(initialState, actionFloored);
+      const state = reducer(defaultMapConfigState, actionFloored);
 
       expect(state.rotation).toEqual(expectedRotation);
     });
@@ -83,7 +83,7 @@ describe('MapConfig Reducer', () => {
     it('sets the reference distance to the incoming value', () => {
       const expectedReferenceDistance = 42;
       const action = MapConfigActions.setReferenceDistance({referenceDistanceInMeters: expectedReferenceDistance});
-      const state = reducer(initialState, action);
+      const state = reducer(defaultMapConfigState, action);
 
       expect(state.referenceDistanceInMeters).toEqual(expectedReferenceDistance);
     });

--- a/src/app/state/map/reducers/map-config.reducer.spec.ts
+++ b/src/app/state/map/reducers/map-config.reducer.spec.ts
@@ -1,7 +1,7 @@
 import {MapConstants} from '../../../shared/constants/map.constants';
 import {MapConfigActions} from '../actions/map-config.actions';
 import {MapConfigState} from '../states/map-config.state';
-import {initialState as defaultMapConfigState, initialState, reducer} from './map-config.reducer';
+import {initialState as defaultMapConfigState, reducer} from './map-config.reducer';
 
 describe('MapConfig Reducer', () => {
   describe('setMapExtent', () => {
@@ -77,6 +77,15 @@ describe('MapConfig Reducer', () => {
       const state = reducer(initialState, actionFloored);
 
       expect(state.rotation).toEqual(expectedRotation);
+    });
+  });
+  describe('setReferenceDistance', () => {
+    it('sets the reference distance to the incoming value', () => {
+      const expectedReferenceDistance = 42;
+      const action = MapConfigActions.setReferenceDistance({referenceDistanceInMeters: expectedReferenceDistance});
+      const state = reducer(initialState, action);
+
+      expect(state.referenceDistanceInMeters).toEqual(expectedReferenceDistance);
     });
   });
 });

--- a/src/app/state/map/reducers/map-config.reducer.ts
+++ b/src/app/state/map/reducers/map-config.reducer.ts
@@ -23,6 +23,7 @@ export const initialState: MapConfigState = {
   initialMapPadding: defaultMapConfig.initialMapPadding,
   initialMapPaddingMobile: defaultMapConfig.initialMapPaddingMobile,
   initialBoundingBox: defaultMapConfig.initialBoundingBox,
+  referenceDistanceInMeters: defaultMapConfig.referenceDistanceInMeters,
 };
 
 export const mapConfigFeature = createFeature({
@@ -98,6 +99,9 @@ export const mapConfigFeature = createFeature({
     on(MapConfigActions.setRotation, (state, {rotation}): MapConfigState => {
       return {...state, rotation: rotation};
     }),
+    on(MapConfigActions.setReferenceDistance, (state, {referenceDistanceInMeters}): MapConfigState => {
+      return {...state, referenceDistanceInMeters};
+    }),
   ),
 });
 
@@ -114,4 +118,5 @@ export const {
   selectIsMaxZoomedOut,
   selectActiveBasemapId,
   selectRotation,
+  selectReferenceDistanceInMeters,
 } = mapConfigFeature;

--- a/src/app/state/map/selectors/favourite-base-config.selector.spec.ts
+++ b/src/app/state/map/selectors/favourite-base-config.selector.spec.ts
@@ -22,6 +22,7 @@ describe('selectFavouriteBaseConfig', () => {
       initialMapPaddingMobile: {left: 0, right: 0, top: 0, bottom: 0},
       initialMapPadding: {left: 0, right: 0, top: 0, bottom: 0},
       initialBoundingBox: {min: {x: 0, y: 0}, max: {x: 0, y: 0}},
+      referenceDistanceInMeters: undefined,
     };
   });
   it('returns the correct subset of the current map config', () => {

--- a/src/app/state/map/selectors/scale-bar-config.selector.spec.ts
+++ b/src/app/state/map/selectors/scale-bar-config.selector.spec.ts
@@ -1,0 +1,90 @@
+import {selectScaleBarConfig} from './scale-bar-config.selector';
+import {MapConstants} from '../../../shared/constants/map.constants';
+
+describe('selectScaleBarConfig', () => {
+  it('returns undefined for an undefined reference length', () => {
+    const actual = selectScaleBarConfig.projector(undefined);
+    expect(actual).toBeUndefined();
+  });
+  describe('unit selection', () => {
+    [
+      {value: 1000, expectedUnit: 'km'},
+      {value: 999.999, expectedUnit: 'm'},
+      {value: 1, expectedUnit: 'm'},
+      {value: 0.99, expectedUnit: 'cm'},
+    ].forEach(({value, expectedUnit}) => {
+      it(`returns ${expectedUnit} for ${value}`, () => {
+        const actual = selectScaleBarConfig.projector(value);
+        expect(actual!.unit).toEqual(expectedUnit);
+      });
+    });
+  });
+
+  describe('centimeter handling', () => {
+    describe('value calculation with fixed breaks', () => {
+      [
+        {value: 0.55, expectedValue: 50},
+        {value: 0.869, expectedValue: 50},
+        {value: 0.5, expectedValue: 50},
+        {value: 0.49, expectedValue: 20},
+        {value: 0.2, expectedValue: 20},
+        {value: 0.19, expectedValue: 10},
+        {value: 0.095, expectedValue: 10},
+        {value: 0.09, expectedValue: 5},
+        {value: 0.05, expectedValue: 5},
+        {value: 0.045, expectedValue: 5},
+        {value: 0.044, expectedValue: 2},
+        {value: 0.015, expectedValue: 2},
+        {value: 0.014, expectedValue: 1},
+        {value: 0.01, expectedValue: 1},
+        {value: 0, expectedValue: 1},
+      ].forEach(({value, expectedValue}) => {
+        it(`returns ${expectedValue} for ${value}`, () => {
+          const actual = selectScaleBarConfig.projector(value);
+          expect(actual!.value).toEqual(expectedValue);
+        });
+      });
+    });
+
+    it('calculates the correct scale bar width', () => {
+      const value = 0.42; // this picks the 20cm scale
+      const ratio = 20 / (value * 100);
+      const expectedWidth = Math.round(MapConstants.MAX_SCALE_BAR_WIDTH_PX * ratio);
+
+      const actual = selectScaleBarConfig.projector(value);
+
+      expect(actual!.scaleBarWidthInPx).toEqual(expectedWidth);
+    });
+  });
+
+  describe('meter and kilometer handling', () => {
+    describe('value calculation with power-based rounding', () => {
+      [
+        {value: 11, expectedValue: 10},
+        {value: 25, expectedValue: 20},
+        {value: 150, expectedValue: 100},
+        {value: 220, expectedValue: 200},
+        {value: 320, expectedValue: 300},
+        {value: 550, expectedValue: 500},
+        {value: 650, expectedValue: 500},
+        {value: 999, expectedValue: 500},
+        {value: 1000, expectedValue: 1},
+      ].forEach(({value, expectedValue}) => {
+        it(`returns ${expectedValue} for ${value}`, () => {
+          const actual = selectScaleBarConfig.projector(value);
+          expect(actual!.value).toEqual(expectedValue);
+        });
+      });
+    });
+
+    it('calculates the correct scale bar width', () => {
+      const value = 420.1; // this picks the 300m scale
+      const ratio = 300 / value;
+      const expectedWidth = Math.round(MapConstants.MAX_SCALE_BAR_WIDTH_PX * ratio);
+
+      const actual = selectScaleBarConfig.projector(value);
+
+      expect(actual!.scaleBarWidthInPx).toEqual(expectedWidth);
+    });
+  });
+});

--- a/src/app/state/map/selectors/scale-bar-config.selector.ts
+++ b/src/app/state/map/selectors/scale-bar-config.selector.ts
@@ -1,0 +1,52 @@
+import {createSelector} from '@ngrx/store';
+import {selectReferenceDistanceInMeters} from '../reducers/map-config.reducer';
+import {MapConstants} from '../../../shared/constants/map.constants';
+import {ScaleBarConfig} from '../../../shared/interfaces/scale-bar-config.interface';
+
+/**
+ * Caclulates the scale bar configuration based on the reference distance in meters. This is based on Leaflet's L.Control.Scale method, but
+ * adapted to also add centimeter scale bars.
+ *
+ * The reference value has to be created using the MapConstants.MAX_SCALE_BAR_WIDTH_PX constant, so the calculated ratio is correct.
+ */
+export const selectScaleBarConfig = createSelector(
+  selectReferenceDistanceInMeters,
+  (referenceDistanceInMeters): ScaleBarConfig | undefined => {
+    if (referenceDistanceInMeters === undefined) {
+      return undefined;
+    }
+
+    /**
+     * Updates the scale bar to meters by rounding to common scale values and calculating the correct ratio.
+     * This is adapted from Leaflet's L.Control.Scale._getRoundNum method
+     * (https://github.com/Leaflet/Leaflet/blob/main/src/control/Control.Scale.js#L117)
+     */
+    if (referenceDistanceInMeters >= 1) {
+      const pow10 = Math.pow(10, `${Math.floor(referenceDistanceInMeters)}`.length - 1);
+      let d = referenceDistanceInMeters / pow10;
+      d = d >= 10 ? 10 : d >= 5 ? 5 : d >= 3 ? 3 : d >= 2 ? 2 : 1;
+      const meters = pow10 * d;
+      const ratio = meters / referenceDistanceInMeters;
+
+      return {
+        scaleBarWidthInPx: Math.round(MapConstants.MAX_SCALE_BAR_WIDTH_PX * ratio),
+        value: meters >= 1000 ? meters / 1000 : meters,
+        unit: meters >= 1000 ? `km` : `m`,
+      };
+    }
+
+    /**
+     * Updates the scale bar to centimeters by finding the closest match and then calculating the ratio.
+     */
+    const breaks = [50, 20, 10, 5, 2, 1];
+    const centimeters = Math.round(referenceDistanceInMeters * 100);
+    const snappedCentimeter = breaks.find((b) => centimeters >= b) || 1;
+    const ratio = snappedCentimeter / (referenceDistanceInMeters * 100);
+
+    return {
+      scaleBarWidthInPx: Math.round(MapConstants.MAX_SCALE_BAR_WIDTH_PX * ratio),
+      value: snappedCentimeter,
+      unit: 'cm',
+    };
+  },
+);

--- a/src/app/state/map/states/map-config.state.ts
+++ b/src/app/state/map/states/map-config.state.ts
@@ -17,6 +17,7 @@ export interface MapConfigState {
   initialMapPadding: InitialMapPadding;
   initialMapPaddingMobile: InitialMapPadding;
   initialBoundingBox: BoundingBox;
+  referenceDistanceInMeters: number | undefined;
 }
 
 export interface InitialMapPadding {

--- a/src/app/testing/map-testing/map.service.stub.ts
+++ b/src/app/testing/map-testing/map.service.stub.ts
@@ -37,8 +37,6 @@ export class MapServiceStub implements MapService {
 
   public assignMapElement(container: HTMLDivElement): void {}
 
-  public assignScaleBarElement(container: HTMLDivElement): void {}
-
   public handleZoom(zoomType: ZoomType): void {}
 
   public setMapCenter(center: PointWithSrs): void {}


### PR DESCRIPTION
This PR adds a custom scale bar that removes the need for using the SDKs `ScaleBarWidget`, which became deprecated and can only be used with `<arcgis-scale-bar>` nested within `<arcgis-map>`. Instead of refactoring everything, we use a similar approach to Leaflet (https://github.com/Leaflet/Leaflet/blob/main/src/control/Control.Scale.js) and rely on selectors to create the logic.

I only added a bit more logic for handling the cm distinction as well - feel free to optimize where you see need :)

Sonar Cloud mentions an issue with the "leaflet" way of getting the nearest number; however, since we rely on leaflet, I did not want to change it.