### PR TITLE
GB3-1763: Fix broken resizeobserver for featureinfo

### DIFF
--- a/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.scss
+++ b/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.scss
@@ -58,7 +58,7 @@ $fixed-border: inset calc(-1 * $border-size) 0 0 0 ktzh-variables.$zh-black100;
 
       // override the upper left cell to be white (as per the design)
       &:first-child > .feature-info-content__table__row__column--header:first-child {
-        background-color: ktzh-variables.$zh-white;
+        background-color: transparent;
         z-index: z-index-variables.$feature-info-content-table-header;
       }
 


### PR DESCRIPTION
This was a tricky one :)

* We need `ResizeObserver` on the column elements because they are automatically resized whenever the outer element (i.e. the FeatureInfo container) is resized
* This is then used to calculate the *maxium width* the resizable column might have (here 80%)
* However, due to our implementation, this had race conditions, leading to the second element ALWAYS triggering the observer callback, and thus, always getting instantly resized to the default width
* Another issue might be that we rely on the resizeobserver with ngTemplate, which have the same identities and that leads to issues with references

The fix I added does the following:
* Proper release of the Observer in our `onDestroy` method
* Resize happens ONLY if the outer element is resized to a smaller size; in that case, we resize to the default
* In either case, we set the new maximum width
* We also need to trigger changedetection because of internal shenanigans of our _actual_ resize library (which is not triggered when just calling `resize`

Also note that I fixed a visibility bug that annoyed me: When changing the width of the window, the top-left column had a higher z-index and thus was visible _over_ the drag shadow. Fixed using `transparent`


<hr>

@EliasFessler Since you were interested in how to debug something like this:
* Find the responsible components (here: `FeatureInfoContentComponent`); can be seen in the DOM
* Analyze the bug:
  * When does it happen? -> on resize
  * Where do we have resize listeners? -> We use our own `ResizeHandler`, and we have additional logic using the aforementioned `ResizeObserver`
* Begin using breakpoints -> which part of the code is triggered when? Why is it always reset to exactly 130px?
* Notice that it happens within the callback, and we have a fixed width setting there
* ????
* Fix bug :D