### PR TITLE
GHUB-7: Expand branch name and commit message convention to accept new jira project name

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -2,7 +2,7 @@
 
 echo "🚀 Checking commit message!"
 message=$(cat "$1")
-valid_commit_pattern='GB3-[0-9][0-9]*: .*'
+valid_commit_pattern='(GB3|GHUB)-[0-9][0-9]*: .*'
 
 if ! echo "$message" | grep -Eq "$valid_commit_pattern"; then
   printf "\033[31m⚠️ Commit message does not adhere to naming convention %s! \033[0m\n" "$valid_commit_pattern"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,7 +6,7 @@ echo ""
 
 echo "🚀 Checking branchname!"
 local_branch_name=$(git rev-parse --abbrev-ref HEAD)
-valid_branch_regex='^(feature|hotfix|bugfix)/gb3-[0-9]+-[a-zA-Z0-9\-]+$'
+valid_branch_regex='^(feature|hotfix|bugfix)/(gb3|ghub)-[0-9]+-[a-zA-Z0-9\-]+$'
 
 if ! echo "$local_branch_name" | grep -Eq "$valid_branch_regex"; then
     printf "\033[31m⚠️ Branchname does not adhere to naming convention %s! \033[0m\n" "$valid_branch_regex"

--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ WIP - add more naming conventions :)
 
 Whenever possible, a Jira ticket should be referenced in both branchname and commit message:
 
-- Branches: `[feature|hotfix]/gb3-[xxx]-[name-of-branch]`, where `xxx` refers to a Jira ticket and the `name-of-branch`
-  is a short summary of the feature/hotfix.`
-- Commits: `GB3-[xxx]: Your commit message`, , where `xxx` refers to a Jira ticket
+- Branches: `[feature|hotfix|bugfix]/[gb3|ghub]-[xxx]-[name-of-branch]`, where `xxx` refers to a Jira ticket and the `name-of-branch`
+  is a short summary of the feature/hotfix/bugfix.`
+- Commits: `[GB3|GHUB]-[xxx]: Your commit message`, , where `xxx` refers to a Jira ticket
 
 Our githooks check for both the branch name and the commit message, but they will only output a warning if they don't
 match. This is because there are times when you _might_ want to deviate from these rules.


### PR DESCRIPTION
- Expand branch name and commit message convention to accept new jira project name