### PR TITLE
GHUB-250: Fix timeslider and timepicker interaction by converting dates to day for the calculateDifferenceBetweenDates

### DIFF
--- a/src/app/map/components/time-slider/time-slider.component.html
+++ b/src/app/map/components/time-slider/time-slider.component.html
@@ -32,7 +32,7 @@
           <mat-datepicker
             #minDatePicker
             [startView]="datePickerStartView"
-            [startAt]="availableDates[this.firstSliderPosition]"
+            [startAt]="availableDates[firstSliderPosition]"
             (yearSelected)="yearOrMonthSelected($event, minDatePicker, true, 'years')"
             (monthSelected)="yearOrMonthSelected($event, minDatePicker, true, 'months')"
           ></mat-datepicker>
@@ -58,7 +58,7 @@
           <mat-datepicker
             #maxDatePicker
             [startView]="datePickerStartView"
-            [startAt]="availableDates[this.secondSliderPosition || 0]"
+            [startAt]="availableDates[secondSliderPosition || 0]"
             (yearSelected)="yearOrMonthSelected($event, maxDatePicker, false, 'years')"
             (monthSelected)="yearOrMonthSelected($event, maxDatePicker, false, 'months')"
           ></mat-datepicker>

--- a/src/app/map/components/time-slider/time-slider.component.html
+++ b/src/app/map/components/time-slider/time-slider.component.html
@@ -3,12 +3,12 @@
   title="{{ timeSliderConfiguration.name }}"
   description="{{ timeSliderConfiguration.description }}"
   [value]="timeExtent | timeExtentToString: timeSliderConfiguration.dateFormat : hasSimpleCurrentValue"
-  [minValue]="availableDates[effectiveMinimumDateIndex] | dateToString: timeSliderConfiguration.dateFormat"
-  [maxValue]="availableDates[effectiveMaximumDateIndex] | dateToString: timeSliderConfiguration.dateFormat"
+  [minValue]="availableDates[minimumDateIndex] | dateToString: timeSliderConfiguration.dateFormat"
+  [maxValue]="availableDates[maximumDateIndex] | dateToString: timeSliderConfiguration.dateFormat"
   [overwriteFooter]="hasDatePicker"
 >
   <ng-container content>
-    <mat-slider [min]="effectiveMinimumDateIndex" [max]="effectiveMaximumDateIndex" [step]="1" color="primary" class="time-slider__slider">
+    <mat-slider [min]="minimumDateIndex" [max]="maximumDateIndex" [step]="1" color="primary" class="time-slider__slider">
       <ng-container *ngIf="this.timeSliderConfiguration.range; else multiSlider">
         <input matSliderThumb (valueChange)="setValidTimeExtent(true)" [(ngModel)]="firstSliderPosition" />
       </ng-container>
@@ -27,23 +27,23 @@
             (dateChange)="selectedDatePickerDate($event.value, true)"
             [matDatepicker]="minDatePicker"
             [min]="availableDates[0]"
-            [max]="availableDates[effectiveMaximumDateIndex - 1]"
+            [max]="availableDates[maximumDateIndex - 1]"
           />
           <mat-datepicker
             #minDatePicker
             [startView]="datePickerStartView"
-            [startAt]="availableDates[effectiveMinimumDateIndex]"
+            [startAt]="availableDates[this.firstSliderPosition]"
             (yearSelected)="yearOrMonthSelected($event, minDatePicker, true, 'years')"
             (monthSelected)="yearOrMonthSelected($event, minDatePicker, true, 'months')"
           ></mat-datepicker>
         </mat-form-field>
         <button
           mat-button
-          [ngClass]="{'time-slider__footer__button--modified': effectiveMinimumDateIndex !== 0}"
+          [ngClass]="{'time-slider__footer__button--modified': minimumDateIndex !== 0}"
           class="time-slider__footer__button"
           (click)="minDatePicker.open()"
         >
-          {{ availableDates[effectiveMinimumDateIndex] | dateToString: timeSliderConfiguration.dateFormat }}
+          {{ availableDates[minimumDateIndex] | dateToString: timeSliderConfiguration.dateFormat }}
         </button>
       </div>
       <div>
@@ -52,24 +52,24 @@
             matInput
             (dateChange)="selectedDatePickerDate($event.value, false)"
             [matDatepicker]="maxDatePicker"
-            [min]="availableDates[effectiveMinimumDateIndex + 1]"
+            [min]="availableDates[minimumDateIndex + 1]"
             [max]="availableDates[availableDates.length - 1]"
           />
           <mat-datepicker
             #maxDatePicker
             [startView]="datePickerStartView"
-            [startAt]="availableDates[effectiveMaximumDateIndex]"
+            [startAt]="availableDates[this.secondSliderPosition || 0]"
             (yearSelected)="yearOrMonthSelected($event, maxDatePicker, false, 'years')"
             (monthSelected)="yearOrMonthSelected($event, maxDatePicker, false, 'months')"
           ></mat-datepicker>
         </mat-form-field>
         <button
           mat-button
-          [ngClass]="{'time-slider__footer__button--modified': effectiveMaximumDateIndex !== availableDates.length - 1}"
+          [ngClass]="{'time-slider__footer__button--modified': maximumDateIndex !== availableDates.length - 1}"
           class="time-slider__footer__button"
           (click)="maxDatePicker.open()"
         >
-          {{ availableDates[effectiveMaximumDateIndex] | dateToString: timeSliderConfiguration.dateFormat }}
+          {{ availableDates[maximumDateIndex] | dateToString: timeSliderConfiguration.dateFormat }}
         </button>
       </div>
     </div>

--- a/src/app/map/components/time-slider/time-slider.component.ts
+++ b/src/app/map/components/time-slider/time-slider.component.ts
@@ -156,29 +156,6 @@ export class TimeSliderComponent implements OnInit, OnChanges {
     return range ? this.timeService.isStringSingleTimeUnitRange(range) : false;
   }
 
-  /**
-   * Returns `true` the given date format contains only one unique unit (e.g. 'years') and the source is either of
-   * type `parameter` or if it's of type `layer` then there is a continuous strictly monotonously rising series of layer dates.
-   */
-  private isRangeContinuousWithinAllowedTimeUnits(timeSliderConfiguration: TimeSliderConfiguration): boolean {
-    let isRangeContinuousWithinAllowedTimeUnits = false;
-    const unit = this.extractUniqueDatePickerUnitFromDateFormat(timeSliderConfiguration.dateFormat);
-    if (unit) {
-      switch (timeSliderConfiguration.sourceType) {
-        case 'parameter':
-          isRangeContinuousWithinAllowedTimeUnits = true;
-          break;
-        case 'layer':
-          isRangeContinuousWithinAllowedTimeUnits = this.isLayerSourceContinuous(
-            <TimeSliderLayerSource>timeSliderConfiguration.source,
-            unit,
-          );
-          break;
-      }
-    }
-    return isRangeContinuousWithinAllowedTimeUnits;
-  }
-
   private extractUniqueDatePickerUnitFromDateFormat(dateFormat: string): DatePickerManipulationUnits | undefined {
     const unit = this.timeSliderService.extractUniqueUnitFromDateFormat(dateFormat);
     if (unit !== undefined && allowedDatePickerManipulationUnits.some((allowedUnit) => allowedUnit === unit)) {

--- a/src/app/map/components/time-slider/time-slider.component.ts
+++ b/src/app/map/components/time-slider/time-slider.component.ts
@@ -164,15 +164,6 @@ export class TimeSliderComponent implements OnInit, OnChanges {
     return undefined;
   }
 
-  private isLayerSourceContinuous(layerSource: TimeSliderLayerSource, unit: DatePickerManipulationUnits): boolean {
-    const dateAsAscendingSortedNumbers = layerSource.layers
-      .map((layer) => this.timeService.createPartialFromString(layer.date, unit))
-      .sort((a, b) => a - b);
-    // all date numbers must be part of a continuous and strictly monotonously rising series each with exactly
-    // one step between them: `date[0] = x` => `date[n] = x + n`
-    return !dateAsAscendingSortedNumbers.some((dateAsNumber, index) => dateAsNumber !== dateAsAscendingSortedNumbers[0] + index);
-  }
-
   private findPositionOfDate(date: Date): number | undefined {
     const index = this.availableDates.findIndex(
       (availableDate) => this.timeService.calculateDifferenceBetweenDates(availableDate, date) === 0,

--- a/src/app/map/components/time-slider/time-slider.component.ts
+++ b/src/app/map/components/time-slider/time-slider.component.ts
@@ -34,8 +34,8 @@ export class TimeSliderComponent implements OnInit, OnChanges {
 
   public timeExtent!: TimeExtent;
 
-  public effectiveMinimumDateIndex!: number;
-  public effectiveMaximumDateIndex!: number;
+  public minimumDateIndex!: number;
+  public maximumDateIndex!: number;
 
   // the time slider shows a simple current value (e.g. `2001` instead of `2001-2002`) if it has a range of exactly one of a single time unit (year, month, ...)
   public hasSimpleCurrentValue: boolean = false;
@@ -52,15 +52,15 @@ export class TimeSliderComponent implements OnInit, OnChanges {
 
   public ngOnInit() {
     this.availableDates = this.timeSliderService.createStops(this.timeSliderConfiguration);
-    this.effectiveMinimumDateIndex = 0;
-    this.effectiveMaximumDateIndex = this.availableDates.length - 1;
+    this.minimumDateIndex = 0;
+    this.maximumDateIndex = this.availableDates.length - 1;
     this.timeExtent = {start: this.initialTimeExtent.start, end: this.initialTimeExtent.end};
     this.firstSliderPosition = this.findPositionOfDate(this.timeExtent.start) ?? 0;
     this.secondSliderPosition = this.timeSliderConfiguration.range ? undefined : this.findPositionOfDate(this.timeExtent.end);
     this.hasSimpleCurrentValue = this.isStringSingleTimeUnitRange(this.timeSliderConfiguration.range);
-
     // date picker
-    this.hasDatePicker = this.isRangeContinuousWithinAllowedTimeUnits(this.timeSliderConfiguration);
+    // enable the date picker its from sourceType parameter
+    this.hasDatePicker = this.timeSliderConfiguration.sourceType === 'parameter';
     if (this.hasDatePicker) {
       this.datePickerUnit = this.extractUniqueDatePickerUnitFromDateFormat(this.timeSliderConfiguration.dateFormat) ?? 'days';
       this.datePickerStartView = this.createDatePickerStartView(this.datePickerUnit);
@@ -94,8 +94,8 @@ export class TimeSliderComponent implements OnInit, OnChanges {
       this.timeSliderConfiguration,
       newTimeExtent,
       hasStartDateChanged,
-      this.availableDates[this.effectiveMinimumDateIndex],
-      this.availableDates[this.effectiveMaximumDateIndex],
+      this.availableDates[this.minimumDateIndex],
+      this.availableDates[this.maximumDateIndex],
     );
 
     // correct the thumb that was modified with the calculated time extent if necessary (e.g. enforcing a minimal range)
@@ -144,9 +144,9 @@ export class TimeSliderComponent implements OnInit, OnChanges {
     const position = this.findPositionOfDate(date);
     if (position !== undefined) {
       if (changedMinimumDate) {
-        this.effectiveMinimumDateIndex = position;
+        this.firstSliderPosition = position;
       } else {
-        this.effectiveMaximumDateIndex = position;
+        this.secondSliderPosition = position;
       }
       this.setValidTimeExtent(changedMinimumDate);
     }

--- a/src/app/shared/interfaces/time-service.interface.ts
+++ b/src/app/shared/interfaces/time-service.interface.ts
@@ -26,7 +26,7 @@ export interface TimeService {
    */
   getDateAsUTCString: (date: Date, format?: string) => string;
   /**
-   * Returns the difference between two dates in milliseconds.
+   * Returns the difference between two dates in full days. Everything smaller (hours, minutes, seconds) is ignored.
    */
   calculateDifferenceBetweenDates: (firstDate: Date, secondDate: Date) => number;
   /**

--- a/src/app/shared/services/dayjs.service.ts
+++ b/src/app/shared/services/dayjs.service.ts
@@ -43,7 +43,7 @@ export class DayjsService implements TimeService {
   }
 
   public calculateDifferenceBetweenDates(firstDate: Date, secondDate: Date): number {
-    return Math.abs(this.createDayjsObject(secondDate).diff(this.createDayjsObject(firstDate)));
+    return Math.abs(this.createDayjsObject(secondDate).startOf('day').diff(this.createDayjsObject(firstDate).startOf('day')));
   }
 
   public getISORangeInMilliseconds(range: string): number {


### PR DESCRIPTION
Convert dates to day for the calculateDifferenceBetweenDates function, hasDatepicker true if timeslider sourceType is parameter (remove isRangeContinuousWithinAllowedTimeUnits constraint), fixate the button date, couple datepicker with timeslider