### PR TITLE
GB3-1765: Fix missing z-index on resize observer

### DIFF
--- a/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.scss
+++ b/src/app/map/components/feature-info-overlay/feature-info-content/feature-info-content.component.scss
@@ -58,7 +58,7 @@ $fixed-border: inset calc(-1 * $border-size) 0 0 0 ktzh-variables.$zh-black100;
 
       // override the upper left cell to be white (as per the design)
       &:first-child > .feature-info-content__table__row__column--header:first-child {
-        background-color: transparent;
+        background-color: ktzh-variables.$zh-white;
         z-index: z-index-variables.$feature-info-content-table-header;
       }
 

--- a/src/app/shared/components/resize-handler/resize-handler.component.scss
+++ b/src/app/shared/components/resize-handler/resize-handler.component.scss
@@ -1,5 +1,6 @@
 @use 'variables/ktzh-design-variables' as ktzh-variables;
 @use 'functions/helper.function' as functions;
+@use 'variables/z-index-variables' as z-index-variables;
 
 $handle-width: 5px;
 $handle-height: 25px;
@@ -80,4 +81,5 @@ $handle-no-hover: $handle-indicator-width double ktzh-variables.$zh-disabled-for
  */
 .resize-active {
   background-color: rgba(ktzh-variables.$zh-black40, 0.1);
+  z-index: z-index-variables.$resize-active;
 }

--- a/src/styles/variables/_z-index-variables.scss
+++ b/src/styles/variables/_z-index-variables.scss
@@ -3,6 +3,7 @@
 $navbar: 400; // should always stay on top, only adjust if you know what you're doing
 $map-overlay: 100;
 $search-window-results: 4;
+$resize-active: 5;
 $map-attribute-filter: 3;
 $basemap-selector: 3;
 $active-map-item-connection-line: 2;


### PR DESCRIPTION
The bug existed because of a fix in https://github.com/gisktzh/gb3-web_ui/pull/203: Previously, the top-left column was visible when resizing the window because it had a z-index. We made it transparent to avoid this, however, that's why the column headers were still visible.

I fixed this by adding a proper z-index to the resize handler and reintroducing the background color for the top-left column.