### PR TITLE
GHUB-0: Fix min-height for mobile icons, coming from new mat version.

### DIFF
--- a/src/styles/mixins/_material.mixin.scss
+++ b/src/styles/mixins/_material.mixin.scss
@@ -121,6 +121,7 @@
   .mat-icon {
     width: $icon-size;
     height: $icon-size;
+    min-height: auto;
 
     svg {
       width: $icon-size;


### PR DESCRIPTION
New version of material components added a `min-height: fit-content;` to mat-icon. We need to explicitly get rid of that for flexbox to center it properly on the y axis.