### PR TITLE
Add --ignore-scripts to pipeline steps

### DIFF
--- a/.github/workflows/node-builds.yml
+++ b/.github/workflows/node-builds.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npm ci
+          npm ci --ignore-scripts
 
       - name: Build for ${{ matrix.environment }}
         run: npm run build-${{ matrix.environment }}

--- a/.github/workflows/node-deploy.yml
+++ b/.github/workflows/node-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           APP_RELEASE: 'EBP Dev Release'
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run build-dev-ebp
           cp ./dist/browser/index.html ./dist/browser/404.html
 

--- a/.github/workflows/node-quality-checks.yml
+++ b/.github/workflows/node-quality-checks.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dependencies and run linter
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run lint
 
   tests:
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install dependencies and run tests
         run: |
-          npm ci
+          npm ci --ignore-scripts
           npm run test-ci
         env:
           # note: this is required with @arcgis/core >=4.32 due to increased memory usage for type checking

--- a/.github/workflows/node-quality-checks.yml
+++ b/.github/workflows/node-quality-checks.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Install dependencies and run tests
         run: |
           npm ci --ignore-scripts
+          node ./node_modules/.bin/puppeteer browsers install
           npm run test-ci
         env:
           # note: this is required with @arcgis/core >=4.32 due to increased memory usage for type checking


### PR DESCRIPTION
Considering the most recent supply chain attacks, this PR tries to mitigate some of them by adding `--ignore-scripts` to all install commands.

More info: 

* https://github.com/valor-software/ngx-bootstrap/issues/6776
* https://socket.dev/blog/tinycolor-supply-chain-attack-affects-40-packages


Issues:

* Tests do not run - because `puppeteer` tries to pull in Chrome after install. As a remedy, we should install chrome directly in a previous step and use `puppeteer-core`