### PR TITLE
GHUB-0: Make layer description nullable as epr Geolion change.

### DIFF
--- a/src/app/shared/interfaces/dataset-layer.interface.ts
+++ b/src/app/shared/interfaces/dataset-layer.interface.ts
@@ -3,7 +3,7 @@ import {LayerAttributes} from './layer-attributes.interface';
 export interface DatasetLayer {
   id: string;
   name: string;
-  description: string;
+  description: string | null;
   dataProcurementType: string;
   path: string | null;
   geometryType: string;

--- a/src/app/shared/models/gb3-api-generated.interfaces.ts
+++ b/src/app/shared/models/gb3-api-generated.interfaces.ts
@@ -890,7 +890,7 @@ export interface Dataset {
     /** Layer GIS-ZH-Nummer */
     giszhnr: string;
     /** Beschreibung des Layers */
-    beschreibung: string;
+    beschreibung: string | null;
     /** Geometrietyp */
     geometrietyp: string;
     /** Pfad\Filename */


### PR DESCRIPTION
Geolion had an API change that makes layer descriptions nullable. We've adapted the backend V3 and V4 already, this PR is to match the new typing by allowing null as possible layer description values.