### PR TITLE
GHUB-423: Explicitly unassign mapview container when component is destroyed.

### DIFF
--- a/src/app/map/components/map-container/map-container.component.ts
+++ b/src/app/map/components/map-container/map-container.component.ts
@@ -1,7 +1,6 @@
-import {AfterViewInit, Component, ElementRef, OnInit, ViewChild, inject} from '@angular/core';
+import {AfterViewInit, Component, ElementRef, OnInit, OnDestroy, ViewChild, inject} from '@angular/core';
 import {FeatureHighlightingService} from '../../services/feature-highlighting.service';
 import {MapService} from '../../interfaces/map.service';
-
 import {MAP_SERVICE} from '../../../app.tokens';
 
 @Component({
@@ -10,7 +9,7 @@ import {MAP_SERVICE} from '../../../app.tokens';
   styleUrls: ['./map-container.component.scss'],
   providers: [FeatureHighlightingService],
 })
-export class MapContainerComponent implements OnInit, AfterViewInit {
+export class MapContainerComponent implements OnInit, OnDestroy, AfterViewInit {
   private readonly mapService = inject<MapService>(MAP_SERVICE);
   private readonly featureHighlightingService = inject(FeatureHighlightingService);
 
@@ -23,5 +22,9 @@ export class MapContainerComponent implements OnInit, AfterViewInit {
 
   public ngAfterViewInit() {
     this.mapService.assignMapElement(this.mainMapRef.nativeElement);
+  }
+
+  public ngOnDestroy() {
+    this.mapService.unassignMapElement();
   }
 }

--- a/src/app/map/interfaces/map.service.ts
+++ b/src/app/map/interfaces/map.service.ts
@@ -18,6 +18,9 @@ export interface MapService extends AddToMapVisitor {
   /** Assigns the map to an element on the HTML */
   assignMapElement(container: HTMLDivElement): void;
 
+  /** Removes the currently assigned map element. */
+  unassignMapElement(): void;
+
   /** Sets the scale of the whole map */
   setScale(scale: number): void;
 

--- a/src/app/map/services/esri-services/esri-map.service.ts
+++ b/src/app/map/services/esri-services/esri-map.service.ts
@@ -336,6 +336,10 @@ export class EsriMapService implements MapService, OnDestroy {
     this.mapView.container = container;
   }
 
+  public unassignMapElement() {
+    this.mapView.container = null;
+  }
+
   public setOpacity(opacity: number, mapItem: ActiveMapItem): void {
     const esriLayer = this.esriMapViewService.findEsriLayer(mapItem.id);
     if (esriLayer) {

--- a/src/app/testing/map-testing/map.service.stub.ts
+++ b/src/app/testing/map-testing/map.service.stub.ts
@@ -47,6 +47,8 @@ export class MapServiceStub implements MapService {
 
   public assignMapElement(container: HTMLDivElement): void {}
 
+  public unassignMapElement(): void {}
+
   public handleZoom(zoomType: ZoomType): void {}
 
   public setMapCenter(center: PointWithSrs): void {}


### PR DESCRIPTION
Hotfix into main as to not merge the Vitest migration to main yet.