### PR TITLE
Prevent git from changing line endings on checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 .husky/commit-msg eol=lf
 .husky/pre-commit eol=lf
+# prevent git from changing line endings on checkout. why is this even a thing.
+* -text
+


### PR DESCRIPTION
Checking the project out from windows currently changes all line endings to clrf. Then prettier shows all files completely red due to the wrong line ending.

This PR adds a setting to prevent git from changing anything in the files, as it should imo be.