### PR TITLE
GHUB-417: Fix filtering and selection of municipality select in data download

### DIFF
--- a/src/app/map/components/map-tools/data-download-select-municipality-dialog/data-download-select-municipality-dialog.component.html
+++ b/src/app/map/components/map-tools/data-download-select-municipality-dialog/data-download-select-municipality-dialog.component.html
@@ -9,14 +9,14 @@
             placeholder="Bitte auswählen"
             aria-label="Gemeinde"
             matInput
+            (input)="filterValue.set($event.target.value)"
             [matAutocomplete]="municipalityAutocomplete"
-            [formField]="municipalityForm.filter"
           />
           <mat-autocomplete
             requireSelection
             #municipalityAutocomplete="matAutocomplete"
             [displayWith]="getMunicipalityName"
-            [formField]="municipalityForm.municipality"
+            (optionSelected)="municipalityForm.municipality().value.set($event.option.value)"
           >
             @for (municipality of filteredMunicipalities(); track municipality) {
               <mat-option [value]="municipality">

--- a/src/app/map/components/map-tools/data-download-select-municipality-dialog/data-download-select-municipality-dialog.component.ts
+++ b/src/app/map/components/map-tools/data-download-select-municipality-dialog/data-download-select-municipality-dialog.component.ts
@@ -7,7 +7,8 @@ import {ApiDialogWrapperComponent} from '../../api-dialog-wrapper/api-dialog-wra
 import {MatFormField, MatLabel, MatInput} from '@angular/material/input';
 import {MatAutocompleteTrigger, MatAutocomplete, MatOption} from '@angular/material/autocomplete';
 import {MatButton} from '@angular/material/button';
-import {form, required, FormField} from '@angular/forms/signals';
+import {form, required, disabled} from '@angular/forms/signals';
+import {FormsModule} from '@angular/forms';
 
 @Component({
   selector: 'data-download-select-municipality-dialog',
@@ -22,7 +23,7 @@ import {form, required, FormField} from '@angular/forms/signals';
     MatAutocomplete,
     MatOption,
     MatButton,
-    FormField,
+    FormsModule,
   ],
 })
 export class DataDownloadSelectMunicipalityDialogComponent {
@@ -31,17 +32,16 @@ export class DataDownloadSelectMunicipalityDialogComponent {
 
   public readonly municipalities = this.store.selectSignal(selectMunicipalities);
   public readonly loadingState = this.store.selectSignal(selectMunicipalitiesLoadingState);
-
-  public readonly municipalityModel = signal<{municipality: Municipality | null; filter: string}>({
+  public readonly municipalityModel = signal<{municipality: Municipality | null}>({
     municipality: null,
-    filter: '',
   });
+  public readonly filterValue = signal<string | null>('');
   public municipalityForm = form(this.municipalityModel, (fieldPath) => {
     required(fieldPath.municipality);
+    disabled(fieldPath.municipality, () => this.loadingState() !== 'loaded');
   });
-  public readonly isMunicipalityFieldDisabled = computed(() => this.loadingState() !== 'loaded');
   public readonly filteredMunicipalities = computed(() => {
-    const filterValue = this.municipalityForm.filter().value().toLowerCase().trim();
+    const filterValue = (this.filterValue() || '').toLowerCase().trim();
     if (filterValue.length === 0) {
       return this.municipalities();
     }


### PR DESCRIPTION
Regression from the signals migration. A mismatch of what mat-autocomplete did and what the input actually expected lead to an app crash while trying to filter for municipalities.