### PR TITLE
AHD-2335: Catch incomplete uploaded drawings via linkedSignals.

### DIFF
--- a/src/app/map/components/drawing-edit-overlay/drawing-edit/line-edit/line-edit.component.ts
+++ b/src/app/map/components/drawing-edit-overlay/drawing-edit/line-edit/line-edit.component.ts
@@ -1,8 +1,14 @@
-import {Component, model} from '@angular/core';
+import {Component, linkedSignal, model} from '@angular/core';
 import {Gb3LineStringStyle} from '../../../../../shared/interfaces/internal-drawing-representation.interface';
 import {SliderEditComponent} from '../slider-edit/slider-edit.component';
 import {ColorPickerEditComponent} from '../color-picker-edit/color-picker-edit.component';
 import {form, FormField} from '@angular/forms/signals';
+
+const DEFAULT_DATA = {
+  strokeOpacity: 1,
+  strokeWidth: 1,
+  strokeColor: '#ff0000',
+};
 
 @Component({
   selector: 'line-edit',
@@ -12,5 +18,12 @@ import {form, FormField} from '@angular/forms/signals';
 })
 export class LineEditComponent {
   public readonly lineStyle = model.required<Gb3LineStringStyle>();
-  public lineStyleForm = form(this.lineStyle);
+  public readonly lineStyleFormModel = linkedSignal({
+    source: this.lineStyle,
+    computation: (value) => ({
+      ...DEFAULT_DATA,
+      ...value,
+    }),
+  });
+  public lineStyleForm = form(this.lineStyleFormModel);
 }

--- a/src/app/map/components/drawing-edit-overlay/drawing-edit/point-edit/point-edit.component.ts
+++ b/src/app/map/components/drawing-edit-overlay/drawing-edit/point-edit/point-edit.component.ts
@@ -1,9 +1,18 @@
-import {Component, model} from '@angular/core';
+import {Component, linkedSignal, model} from '@angular/core';
 import {Gb3PointStyle} from '../../../../../shared/interfaces/internal-drawing-representation.interface';
 import {SliderEditComponent} from '../slider-edit/slider-edit.component';
 import {ColorPickerEditComponent} from '../color-picker-edit/color-picker-edit.component';
 import {MatDivider} from '@angular/material/divider';
 import {form, FormField} from '@angular/forms/signals';
+
+const DEFAULT_DATA = {
+  strokeWidth: 1,
+  strokeOpacity: 1,
+  strokeColor: '#ff0000',
+  fillOpacity: 1,
+  fillColor: '#ff0000',
+  pointRadius: 1,
+};
 
 @Component({
   selector: 'point-edit',
@@ -13,5 +22,12 @@ import {form, FormField} from '@angular/forms/signals';
 })
 export class PointEditComponent {
   public readonly pointStyle = model.required<Gb3PointStyle>();
-  public pointStyleForm = form(this.pointStyle);
+  public readonly pointStyleFormModel = linkedSignal({
+    source: this.pointStyle,
+    computation: (value) => ({
+      ...DEFAULT_DATA,
+      ...value,
+    }),
+  });
+  public pointStyleForm = form(this.pointStyleFormModel);
 }

--- a/src/app/map/components/drawing-edit-overlay/drawing-edit/polygon-edit/polygon-edit.component.ts
+++ b/src/app/map/components/drawing-edit-overlay/drawing-edit/polygon-edit/polygon-edit.component.ts
@@ -1,9 +1,17 @@
-import {Component, model} from '@angular/core';
+import {Component, linkedSignal, model} from '@angular/core';
 import {Gb3PolygonStyle} from '../../../../../shared/interfaces/internal-drawing-representation.interface';
 import {SliderEditComponent} from '../slider-edit/slider-edit.component';
 import {ColorPickerEditComponent} from '../color-picker-edit/color-picker-edit.component';
 import {MatDivider} from '@angular/material/divider';
 import {form, FormField} from '@angular/forms/signals';
+
+const DEFAULT_DATA = {
+  strokeWidth: 1,
+  strokeOpacity: 1,
+  strokeColor: '#ff0000',
+  fillOpacity: 1,
+  fillColor: '#ff0000',
+};
 
 @Component({
   selector: 'polygon-edit',
@@ -13,5 +21,12 @@ import {form, FormField} from '@angular/forms/signals';
 })
 export class PolygonEditComponent {
   public readonly polygonStyle = model.required<Gb3PolygonStyle>();
-  public polygonStyleForm = form(this.polygonStyle);
+  public readonly polygonStyleFormModel = linkedSignal({
+    source: this.polygonStyle,
+    computation: (value) => ({
+      ...DEFAULT_DATA,
+      ...value,
+    }),
+  });
+  public polygonStyleForm = form(this.polygonStyleFormModel);
 }

--- a/src/app/map/components/drawing-edit-overlay/drawing-edit/symbol-edit/symbol-edit.component.ts
+++ b/src/app/map/components/drawing-edit-overlay/drawing-edit/symbol-edit/symbol-edit.component.ts
@@ -1,10 +1,15 @@
 import {Gb3SymbolStyle} from './../../../../../shared/interfaces/internal-drawing-representation.interface';
-import {Component, model} from '@angular/core';
+import {Component, linkedSignal, model} from '@angular/core';
 import {DrawingSymbolsComponent} from '../../../drawing-symbols/drawing-symbols.component';
 import {DrawingSymbolDefinition} from 'src/app/shared/interfaces/drawing-symbol/drawing-symbol-definition.interface';
 import {debounce, form, required} from '@angular/forms/signals';
 
 const INPUT_DEBOUNCE_IN_MS = 10;
+
+const DEFAULT_STYLE = {
+  symbolSize: 30,
+  symbolRotation: 0,
+};
 
 @Component({
   selector: 'symbol-edit',
@@ -18,7 +23,18 @@ export class SymbolEditComponent {
     selectedSymbol: DrawingSymbolDefinition | null;
   }>();
 
-  public symbolStyleForm = form(this.symbolStyle, (fieldPath) => {
+  public readonly symbolStyleFormModel = linkedSignal({
+    source: this.symbolStyle,
+    computation: (value) => ({
+      selectedSymbol: value.selectedSymbol,
+      style: {
+        ...DEFAULT_STYLE,
+        ...value.style,
+      },
+    }),
+  });
+
+  public symbolStyleForm = form(this.symbolStyleFormModel, (fieldPath) => {
     required(fieldPath.selectedSymbol);
     debounce(fieldPath.selectedSymbol, INPUT_DEBOUNCE_IN_MS);
     debounce(fieldPath.style.symbolSize, INPUT_DEBOUNCE_IN_MS);

--- a/src/app/map/components/drawing-edit-overlay/drawing-edit/text-edit/text-edit.component.ts
+++ b/src/app/map/components/drawing-edit-overlay/drawing-edit/text-edit/text-edit.component.ts
@@ -1,4 +1,4 @@
-import {Component, model} from '@angular/core';
+import {Component, linkedSignal, model} from '@angular/core';
 import {Gb3TextStyle} from '../../../../../shared/interfaces/internal-drawing-representation.interface';
 import {MapConstants} from '../../../../../shared/constants/map.constants';
 import {MatFormField, MatLabel, MatInput} from '@angular/material/input';
@@ -9,6 +9,15 @@ import {ColorPickerEditComponent} from '../color-picker-edit/color-picker-edit.c
 import {debounce, form, FormField, maxLength, required} from '@angular/forms/signals';
 
 const INPUT_DEBOUNCE_IN_MS = 10;
+
+const DEFAULT_STYLE = {
+  fontSize: 0,
+  fontColor: '#ff0000',
+  haloRadius: 1,
+  haloColor: '#ff0000',
+  labelYOffset: 1,
+};
+
 @Component({
   selector: 'text-edit',
   templateUrl: './text-edit.component.html',
@@ -21,7 +30,18 @@ export class TextEditComponent {
     label: string;
   }>();
 
-  public textStyleForm = form(this.textStyle, (fieldPath) => {
+  public readonly textStyleFormModel = linkedSignal({
+    source: this.textStyle,
+    computation: (value) => ({
+      label: value.label || '',
+      style: {
+        ...DEFAULT_STYLE,
+        ...value.style,
+      },
+    }),
+  });
+
+  public textStyleForm = form(this.textStyleFormModel, (fieldPath) => {
     maxLength(fieldPath.label, MapConstants.TEXT_DRAWING_MAX_LENGTH);
     required(fieldPath.label);
     debounce(fieldPath.label, INPUT_DEBOUNCE_IN_MS);


### PR DESCRIPTION
Bug report only contained the line edit case. The attached drawing was missing strokeOpacity from all lines, which lead to a crash since the strokeOpacity field was missing from the form. The implementation via linkedSignal lets the forms go to a sensible default in that case.