### PR TITLE
GHUB-467: Prevent the attribute filter reset on mobile

### DIFF
--- a/src/app/state/map/effects/map-ui.effects.spec.ts
+++ b/src/app/state/map/effects/map-ui.effects.spec.ts
@@ -166,9 +166,10 @@ describe('MapUiEffects', () => {
   });
 
   describe('closeAttributeFilterIfAttributeFilterItemIsUndefined$', () => {
-    it('dispatches MapUiActions.setAttributeFilterVisibility() when the current mapAttributeFilter is undefined', () => {
+    it('dispatches MapUiActions.setAttributeFilterVisibility() when the current mapAttributeFilter is undefined on desktop', () => {
       const activeMapItem = createGb2WmsMapItemMock('123');
       store.overrideSelector(selectMapAttributeFiltersItem, undefined);
+      store.overrideSelector(selectScreenMode, 'regular');
 
       const expectedAction = MapUiActions.setAttributeFilterVisibility({isVisible: false});
 
@@ -176,6 +177,23 @@ describe('MapUiEffects', () => {
       effects.closeAttributeFilterIfAttributeFilterItemIsUndefined$.subscribe((action) => {
         expect(action).toEqual(expectedAction);
       });
+    });
+
+    it('does not dispatch MapUiActions.setAttributeFilterVisibility() when the current mapAttributeFilter is undefined on mobile', async () => {
+      vi.useFakeTimers();
+
+      const activeMapItem = createGb2WmsMapItemMock('123');
+      store.overrideSelector(selectMapAttributeFiltersItem, undefined);
+      store.overrideSelector(selectScreenMode, 'mobile');
+      let actualAction;
+
+      actions$ = of(ActiveMapItemActions.removeActiveMapItem({activeMapItem}));
+      effects.closeAttributeFilterIfAttributeFilterItemIsUndefined$.subscribe((action) => (actualAction = action));
+      await vi.runAllTimersAsync();
+
+      expect(actualAction).toBeUndefined();
+
+      vi.useRealTimers();
     });
 
     it('does not dispatch MapUiActions.setAttributeFilterVisibility() when the mapAttributeFilter is defined', async () => {

--- a/src/app/state/map/effects/map-ui.effects.ts
+++ b/src/app/state/map/effects/map-ui.effects.ts
@@ -131,6 +131,8 @@ export class MapUiEffects {
       ofType(ActiveMapItemActions.removeActiveMapItem),
       concatLatestFrom(() => this.store.select(selectMapAttributeFiltersItem)),
       filter(([__, attributeFilterItem]) => attributeFilterItem === undefined),
+      concatLatestFrom(() => this.store.select(selectScreenMode)),
+      filter(([_, screenMode]) => screenMode !== 'mobile'),
       map(() => MapUiActions.setAttributeFilterVisibility({isVisible: false})),
     );
   });


### PR DESCRIPTION
Prevent the attribute filter reset on mobile since it closed the bottom drawer which is used for the layers at that moment.